### PR TITLE
code for getting multiple global-uids for one table in a batch

### DIFF
--- a/gemfiles/rails2.gemfile.lock
+++ b/gemfiles/rails2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /Users/ben/src/global_uid
   specs:
-    global_uid (1.2.3)
+    global_uid (1.2.6)
       activerecord
       activesupport
 

--- a/gemfiles/rails2mysql2.gemfile.lock
+++ b/gemfiles/rails2mysql2.gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: /Users/ben/src/global_uid
   specs:
-    global_uid (1.2.3)
+    global_uid (1.2.6)
       activerecord
       activesupport
 

--- a/gemfiles/rails3.gemfile.lock
+++ b/gemfiles/rails3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /Users/ben/src/global_uid
   specs:
-    global_uid (1.2.3)
+    global_uid (1.2.6)
       activerecord
       activesupport
 

--- a/lib/global_uid/active_record_extension.rb
+++ b/lib/global_uid/active_record_extension.rb
@@ -76,7 +76,7 @@ module GlobalUid
         return id if id
 
         if @should_reserve_global_uids
-          @reserved_global_uids += GlobalUid::Base.get_multiples_for_class(self, @should_reserve_global_uids)
+          @reserved_global_uids += GlobalUid::Base.get_many_uids_for_class(self, @should_reserve_global_uids)
           @reserved_global_uids.shift
         else
           nil

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -195,7 +195,7 @@ module GlobalUid
       raise NoServersAvailableException, "All global UID servers are gone!"
     end
 
-    def self.get_multiples_for_class(klass, n, options = {})
+    def self.get_many_uids_for_class(klass, n, options = {})
       with_connections do |connection|
         GlobalUidTimer.timeout(self.global_uid_options[:query_timeout], TimeoutException) do
           connection.transaction do

--- a/test/global_uid_test.rb
+++ b/test/global_uid_test.rb
@@ -244,9 +244,9 @@ class GlobalUIDTest < ActiveSupport::TestCase
       end
 
       should "get bulk ids" do
-        res = GlobalUid::Base.get_multiples_for_class(WithGlobalUID, 10)
+        res = GlobalUid::Base.get_many_uids_for_class(WithGlobalUID, 10)
         assert res.size == 10
-        res += GlobalUid::Base.get_multiples_for_class(WithGlobalUID, 10)
+        res += GlobalUid::Base.get_many_uids_for_class(WithGlobalUID, 10)
         assert res.uniq.size == 20
       end
     end


### PR DESCRIPTION
@tsturge and also for Palomino -- this is a way that code that does lots of inserts can get like 100 global-uids at once.  Should be very useful for a bunch of the stats jobs, and also things like the automation-job-enquerer.

I'm especially interested in a review of what happens within the transaction, which is:

```
   SELECT id for update
   update row 
  SELECT value back
```
