### PR TITLE
Make sure default ids are overwritten

### DIFF
--- a/lib/global_uid/active_record_extension.rb
+++ b/lib/global_uid/active_record_extension.rb
@@ -22,9 +22,7 @@ module GlobalUid
         return
       end
 
-      # Morten, Josh, and Ben have discussed this particular line of code, whether "||=" or "=" is correct.
-      # "||=" allows for more flexibility and more correct behavior (crashing) upon EBCAK
-      self.id ||= global_uid
+      self.id = global_uid
     end
 
     module ClassMethods


### PR DESCRIPTION
In Help Center we need to create Tagging records in our tests, but we've run into an issue with Global UID. The `taggings` table defines a default value for the `id` column of 0. I guess that Rails 2.3 ignored that, but Rails 3.2 loads it before creation. Since there was already a value, the id would always be 0, causing the second write to fail.

As I see it, we should either:

1) Always force a global uid,
2) handle 0 ids,
3) change the `taggings` table.

The first option would be quickest.

/cc @morten @staugaard 
