### PR TITLE
use_server_variables is no longer a configuration option as it is too dangerous

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,6 @@ Here's a complete list of the options you can use:
     :connection_retry     10.minutes
             After failing to connect or query a UID server, how long before we retry
 
-    :use_server_variables false
-            If set, this gem will call "set @@auto_increment_offset" in order to setup the global uid servers.
-            good for test/development, not so much for production.
     :notifier             A proc calling ActiveRecord::Base.logger
             This proc is called with two parameters upon UID server failure -- an exception and a message
 

--- a/lib/global_uid.rb
+++ b/lib/global_uid.rb
@@ -8,6 +8,8 @@ module GlobalUid
   class NoServersAvailableException < Exception ; end
   class ConnectionTimeoutException < Exception ; end
   class TimeoutException < Exception ; end
+
+  autoload :ServerVariables, "global_uid/server_variables"
 end
 
 ActiveRecord::Base.send(:include, GlobalUid::ActiveRecordExtension)

--- a/lib/global_uid/server_variables.rb
+++ b/lib/global_uid/server_variables.rb
@@ -1,0 +1,29 @@
+# This module is good for testing and development, not so much for production.
+# Please note that this is unreliable -- if you lose your CX to the server
+# and auto-reconnect, you will be utterly hosed.  Much better to dedicate a server
+# or two to the cause, and set their auto_increment_increment globally.
+#
+# You can include this module in tests like this:
+#   GlobalUid::Base.extend(GlobalUid::ServerVariables)
+#
+module GlobalUid
+  module ServerVariables
+
+    def self.extended(base)
+      base.singleton_class.send(:alias_method, :new_connection_without_server_variables, :new_connection)
+      base.singleton_class.send(:alias_method, :new_connection, :new_connection_with_server_variables)
+    end
+
+    def new_connection_with_server_variables(name, connection_timeout, offset, increment_by)
+      con = new_connection_without_server_variables(name, connection_timeout, offset, increment_by)
+
+      if con
+        con.execute("set @@auto_increment_increment = #{increment_by}")
+        con.execute("set @@auto_increment_offset = #{offset}")
+      end
+
+      con
+    end
+
+  end
+end

--- a/test/global_uid_test.rb
+++ b/test/global_uid_test.rb
@@ -282,7 +282,7 @@ class GlobalUIDTest < ActiveSupport::TestCase
     context "With a timing out server" do
       setup do
         reset_connections!
-        @a_decent_cx = GlobalUid::Base.new_connection(GlobalUid::Base.global_uid_servers.first, 50, 1, 5, true)
+        @a_decent_cx = GlobalUid::Base.new_connection(GlobalUid::Base.global_uid_servers.first, 50, 1, 5)
         ActiveRecord::Base.stubs(:mysql_connection).raises(GlobalUid::ConnectionTimeoutException).then.returns(@a_decent_cx)
         @connections = GlobalUid::Base.get_connections
       end
@@ -463,7 +463,6 @@ class GlobalUIDTest < ActiveSupport::TestCase
 
   def restore_defaults!
     GlobalUid::Base.global_uid_options[:disabled] = false
-    GlobalUid::Base.global_uid_options[:use_server_variables] = true
     GlobalUid::Base.global_uid_options[:dry_run] = false
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,13 +13,13 @@ require "mocha"
 require "global_uid"
 
 GlobalUid::Base.global_uid_options = {
-  :use_server_variables => true,
   :disabled   => false,
   :id_servers => [
     "test_id_server_1",
     "test_id_server_2"
   ]
 }
+GlobalUid::Base.extend(GlobalUid::ServerVariables)
 
 yaml = YAML::load(IO.read(File.dirname(__FILE__) + "/config/database.yml"))
 


### PR DESCRIPTION
If you want to use server variables you can include the new module:

`GlobalUid::Base.extend(GlobalUid::ServerVariables)`

@morten @marcosvm @osheroff 
