### PR TITLE
Adds class method to enable global_uid

### DIFF
--- a/lib/global_uid/active_record_extension.rb
+++ b/lib/global_uid/active_record_extension.rb
@@ -48,6 +48,10 @@ module GlobalUid
         @global_uid_disabled = true
       end
 
+      def enable_global_uid
+        @global_uid_disabled = false
+      end
+
       def global_uid_table
         GlobalUid::Base.id_table_from_name(self.table_name)
       end


### PR DESCRIPTION
We're disabling global_uid in certain classes in individual tests, those require deterministic ids and need to re-enable them afterwards.
