### PR TITLE
Use mysql2 instead of mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Shove this in your Gemfile and smoke it
 First configure some databases in database.yml in the normal way.
 
     id_server_1:
-      adapter: mysql
+      adapter: mysql2
       host: id_server_db1.prod
       port: 3306
 
     id_server_2:
-        adapter: mysql
+        adapter: mysql2
         host: id_server_db2.prod
         port: 3306
 

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -66,7 +66,7 @@ module GlobalUid
       config = ActiveRecord::Base.configurations[name]
       c = config.symbolize_keys
 
-      raise "No global_uid support for adapter #{c[:adapter]}" unless ['mysql', 'mysql2'].include?(c[:adapter])
+      raise "No global_uid support for adapter #{c[:adapter]}" if c[:adapter] != 'mysql2'
 
       con = nil
       begin

--- a/test/config/database.yml.example
+++ b/test/config/database.yml.example
@@ -1,19 +1,19 @@
 test:
-  adapter: mysql
+  adapter: mysql2
   encoding: utf8
   database: global_uid_test
   username: root
   password:
 
 test_id_server_1:
-  adapter: mysql
+  adapter: mysql2
   encoding: utf8
   database: global_uid_test_id_server_1
   username: root
   password:
 
 test_id_server_2:
-  adapter: mysql
+  adapter: mysql2
   encoding: utf8
   database: global_uid_test_id_server_2
   username: root


### PR DESCRIPTION
Do we still support using the `mysql` gem?

cc/ @osheroff @grosser 
