### PR TITLE
Fix order in which we call the aliased create_table

### DIFF
--- a/lib/global_uid/migration_extension.rb
+++ b/lib/global_uid/migration_extension.rb
@@ -16,11 +16,6 @@ module GlobalUid
         options.merge!(:id => false)
       end
 
-      if uid_enabled
-        id_table_name = options[:global_uid_table] || GlobalUid::Base.id_table_from_name(name)
-        GlobalUid::Base.create_uid_tables(id_table_name, options)
-      end
-
       create_table_without_global_uid(name, options) { |t|
         if remove_auto_increment
           # need to honor specifically named tables
@@ -29,6 +24,12 @@ module GlobalUid
         end
         blk.call(t) if blk
       }
+
+      if uid_enabled
+        id_table_name = options[:global_uid_table] || GlobalUid::Base.id_table_from_name(name)
+        GlobalUid::Base.create_uid_tables(id_table_name, options)
+      end
+
     end
 
     def drop_table_with_global_uid(name, options = {})


### PR DESCRIPTION
At least under rails 4, the guts of create_table (with force: true) will
call drop_table.  The order in which the actions happened meant that we
would create the global_uid tables and then happily drop them.

this really only happened with force: true, in schema.rb.

@yadavsaroj @grosser @gabetax 
