### PR TITLE
global-uid was crazily un-thread-safe before.  This fixes.

### DIFF
--- a/gemfiles/rails3.gemfile.lock
+++ b/gemfiles/rails3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    global_uid (1.4.1)
+    global_uid (2.0.2)
       activerecord (>= 3.2.0, < 5.0)
       activesupport
 

--- a/gemfiles/rails4.gemfile.lock
+++ b/gemfiles/rails4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    global_uid (1.4.1)
+    global_uid (2.0.2)
       activerecord (>= 3.2.0, < 5.0)
       activesupport
 


### PR DESCRIPTION
A threaded server will have to pay some cost in global uid connection, but hey, at least it'll work.

@gabetax @yadavsaroj 
