### PR TITLE
Inherit global_uid_disabled from LHS of HABTM associations on Rails 4.1+

### DIFF
--- a/lib/global_uid.rb
+++ b/lib/global_uid.rb
@@ -1,5 +1,6 @@
 require "global_uid/base"
 require "global_uid/active_record_extension"
+require "global_uid/has_and_belongs_to_many_builder_extension"
 require "global_uid/migration_extension"
 require "global_uid/schema_dumper_extension"
 
@@ -13,6 +14,11 @@ end
 
 ActiveRecord::Base.send(:include, GlobalUid::ActiveRecordExtension)
 ActiveRecord::Migration.send(:prepend, GlobalUid::MigrationExtension)
+
+if ActiveRecord::VERSION::MAJOR >= 4 && ActiveRecord::VERSION::MINOR >= 1
+  ActiveRecord::Associations::Builder::HasAndBelongsToMany.send(:include, GlobalUid::HasAndBelongsToManyBuilderExtension)
+end
+
 if ActiveRecord::VERSION::MAJOR == 4 && RUBY_VERSION >= '2'
   ActiveRecord::SchemaDumper.send(:prepend, GlobalUid::SchemaDumperExtension)
 end

--- a/lib/global_uid/has_and_belongs_to_many_builder_extension.rb
+++ b/lib/global_uid/has_and_belongs_to_many_builder_extension.rb
@@ -1,0 +1,15 @@
+module GlobalUid
+  module HasAndBelongsToManyBuilderExtension
+    def self.included(base)
+      base.class_eval do
+        alias_method_chain :through_model, :inherit_global_uid_disabled_from_lhs
+      end
+    end
+
+    def through_model_with_inherit_global_uid_disabled_from_lhs
+      model = through_model_without_inherit_global_uid_disabled_from_lhs
+      model.disable_global_uid if model.left_reflection.klass.global_uid_disabled
+      model
+    end
+  end
+end

--- a/test/global_uid_test.rb
+++ b/test/global_uid_test.rb
@@ -74,6 +74,15 @@ end
 class ParentSubclassSubclass < ParentSubclass
 end
 
+class Account < ActiveRecord::Base
+  disable_global_uid
+  has_and_belongs_to_many :people
+end
+
+class Person < ActiveRecord::Base
+  has_and_belongs_to_many :account
+end
+
 ActiveRecord::Migration.verbose = false
 
 describe GlobalUid do
@@ -253,6 +262,15 @@ describe GlobalUid do
         after do
           CreateWithoutGlobalUIDs.down
           CreateWithNoParams.down
+        end
+      end
+    end
+
+    if ActiveRecord::VERSION::STRING >= '4.1.0'
+      describe "has_and_belongs_to_many associations" do
+        it "inherits global_uid_disabled from the left-hand-side of the association" do
+          assert Account::HABTM_People.global_uid_disabled
+          refute Person::HABTM_Account.global_uid_disabled
         end
       end
     end


### PR DESCRIPTION
:koala:

Inherit the global_uid_disabled state of models from the left-hand-side of a has_and_belongs_to_many association. Without this patch, any models using has_and_belongs_to_many that also have Global UID disabled will get Global UID errors on the join table association complaining that the corresponding table for that model does not exist.

Conceptually similar to https://github.com/zendesk/active_record_shards/commit/6c740539b3f2a3d9f98148424ae37056ed16b1be

/cc @zendesk/quokka @bquorning @pschambacher @grosser @osheroff

### Risks
 - Only fixes the problem on Rails 4.1+
 - Change in behaviour for has_and_belongs_to_many associations if the previous behaviour was expected