### PR TITLE
Simpler implementation of generate_many_uids

### DIFF
--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    global_uid (2.0.2)
+    global_uid (3.0.0)
       activerecord (>= 3.2.0, < 5.0)
       activesupport
 
@@ -31,7 +31,7 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
     mysql2 (0.3.16)
-    rake (10.3.2)
+    rake (10.4.2)
     tzinfo (0.3.39)
     wwtd (0.5.3)
 

--- a/gemfiles/rails4.0.gemfile.lock
+++ b/gemfiles/rails4.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    global_uid (2.0.2)
+    global_uid (3.0.0)
       activerecord (>= 3.2.0, < 5.0)
       activesupport
 
@@ -35,7 +35,7 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
     mysql2 (0.3.16)
-    rake (10.3.2)
+    rake (10.4.2)
     thread_safe (0.3.4)
     tzinfo (0.3.39)
     wwtd (0.5.3)

--- a/gemfiles/rails4.1.gemfile.lock
+++ b/gemfiles/rails4.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    global_uid (2.0.2)
+    global_uid (3.0.0)
       activerecord (>= 3.2.0, < 5.0)
       activesupport
 
@@ -33,7 +33,7 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mysql2 (0.3.16)
-    rake (10.3.2)
+    rake (10.4.2)
     thread_safe (0.3.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    global_uid (2.0.2)
+    global_uid (3.0.0)
       activerecord (>= 3.2.0, < 5.0)
       activesupport
 
@@ -33,7 +33,7 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mysql2 (0.3.16)
-    rake (10.3.2)
+    rake (10.4.2)
     thread_safe (0.3.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)

--- a/lib/global_uid/active_record_extension.rb
+++ b/lib/global_uid/active_record_extension.rb
@@ -42,6 +42,12 @@ module GlobalUid
         GlobalUid::Base.get_uid_for_class(self, options)
       end
 
+      def generate_many_uids(count, options = {})
+        uid_table_name  = self.global_uid_table
+        self.ensure_global_uid_table
+        GlobalUid::Base.get_many_uids_for_class(self, count, options)
+      end
+
       def disable_global_uid
         @global_uid_disabled = true
       end

--- a/lib/global_uid/active_record_extension.rb
+++ b/lib/global_uid/active_record_extension.rb
@@ -37,14 +37,12 @@ module GlobalUid
       end
 
       def generate_uid(options = {})
-        uid_table_name  = self.global_uid_table
-        self.ensure_global_uid_table
+        ensure_global_uid_table
         GlobalUid::Base.get_uid_for_class(self, options)
       end
 
       def generate_many_uids(count, options = {})
-        uid_table_name  = self.global_uid_table
-        self.ensure_global_uid_table
+        ensure_global_uid_table
         GlobalUid::Base.get_many_uids_for_class(self, count, options)
       end
 

--- a/test/global_uid_test.rb
+++ b/test/global_uid_test.rb
@@ -466,15 +466,9 @@ describe GlobalUid do
     end
 
     it "generates many unique ids" do
-      seen = {}
       uids = WithGlobalUID.generate_many_uids(100)
-      last_uid = nil
-      uids.each do |uid|
-        assert !seen.has_key?(uid)
-        seen[uid] = 1
-        assert uid > last_uid if last_uid
-        last_uid = uid
-      end
+      uids.sort.must_equal uids
+      uids.uniq.must_equal uids
     end
 
     after do

--- a/test/global_uid_test.rb
+++ b/test/global_uid_test.rb
@@ -460,6 +460,28 @@ describe GlobalUid do
     end
   end
 
+  describe "generate_many_uids" do
+    before do
+      CreateWithNoParams.up
+    end
+
+    it "generates many unique ids" do
+      seen = {}
+      uids = WithGlobalUID.generate_many_uids(100)
+      last_uid = nil
+      uids.each do |uid|
+        assert !seen.has_key?(uid)
+        seen[uid] = 1
+        assert uid > last_uid if last_uid
+        last_uid = uid
+      end
+    end
+
+    after do
+      CreateWithNoParams.down
+    end
+  end
+
   private
 
   def test_unique_ids


### PR DESCRIPTION
`generate_many_uids` was removed in the last wave of [Rails 4.x upgrading](https://github.com/zendesk/global_uid/pull/22)

Sometimes, allocating uid's in bulk is useful.

Generating 1000 uid's one at a time takes about half a second locally:
```
zendesk(dev)> Benchmark.realtime { 1000.times { ActiveRecord::Base.connection.insert "replace into global_uids_1.tickets_ids (stub) values ('a')" } }
=> 0.604114233
```

I thought maybe wrapping that in a transaction would help, but it didn't:
```
zendesk(dev)> Benchmark.realtime { ActiveRecord::Base.transaction { 1000.times { ActiveRecord::Base.connection.insert "replace into global_uids_1.tickets_ids (stub) values ('a')" } } }
=> 0.681438674
```

Now check this out, a single SQL statement with a multiple-row insert of 1000 rows (which of course all end up replacing the same row in a global uid table):

```
zendesk(dev)> sql = 'replace into global_uids_1.tickets_ids (stub) values ' + (["('a')"]*1000).join(',')
...
zendesk(dev)> Benchmark.realtime { ActiveRecord::Base.connection.insert sql }
=> 0.01164234
zendesk(dev)> Benchmark.realtime { ActiveRecord::Base.connection.insert sql }
=> 0.008737491
zendesk(dev)> Benchmark.realtime { ActiveRecord::Base.connection.insert sql }
=> 0.009663456
zendesk(dev)>
```

That's 100,000 id's generated per second instead of 1,666 per second with the individual approach.

My read of the [MySQL docs](https://dev.mysql.com/doc/refman/5.0/en/ansi-diff-transactions.html) is that the multiple row `REPLACE` is atomic, so the id's will always be consecutive.

The multiple row approach is simpler than the `UPDATE id = id + @@auto_increment_increment * n` approach we used to have, and doesn't tickle the [weird behavior in InnoDB](https://github.com/zendesk/global_uid/pull/15) with modifying auto_increment counters.

I'm not suggesting we add back the fancy queueing up of bulk-generated uid's for automagic use in newly created AR objects ... I just want a bulk allocator I can call manually when needed.

@osheroff @bquorning @grosser @steved555 @morten @zendesk/archer 

### Risks
 - None unless you actually call generate_many_uids in your code. Since it's a simple REPLACE query, risk of something going wrong is pretty low, lower than the original many uids approach.