### PR TITLE
don't use global_uids for SchemaMigration model

### DIFF
--- a/lib/global_uid.rb
+++ b/lib/global_uid.rb
@@ -15,6 +15,10 @@ end
 ActiveRecord::Base.send(:include, GlobalUid::ActiveRecordExtension)
 ActiveRecord::Migration.send(:prepend, GlobalUid::MigrationExtension)
 
+if defined?(ActiveRecord::SchemaMigration)
+  ActiveRecord::SchemaMigration.disable_global_uid
+end
+
 if ActiveRecord::VERSION::MAJOR >= 4 && ActiveRecord::VERSION::MINOR >= 1
   ActiveRecord::Associations::Builder::HasAndBelongsToMany.send(:include, GlobalUid::HasAndBelongsToManyBuilderExtension)
 end


### PR DESCRIPTION
@zendesk/octo @osheroff 

I didn't look *too* hard, but I couldn't actually find a schema_migrations table during these tests, is it just disabled if it doesn't exist?