### PR TITLE
INFR-2968 Reset MySQL connections after fork

### DIFF
--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -24,11 +24,12 @@ module GlobalUid
     }
 
     def self.servers
-      Thread.current[:servers]
+      # Thread local storage is inheritted on `fork`, include the pid
+      Thread.current["global_uid_servers_#{$$}"]
     end
 
     def self.servers=(s)
-      Thread.current[:servers] = s
+      Thread.current["global_uid_servers_#{$$}"] = s
     end
 
     def self.create_uid_tables(id_table_name, options={})


### PR DESCRIPTION
We encountered a bug where global_uid could produce duplicate ids. This happens when a MySQL connection is established in the parent process (e.g. unicorn), not being reset on `fork`, so that all the child processes share the same client. This causes a race between the execution of `mysql_query ` and `mysql_insert_id` in the underlying c client, causing one process to read the insert id state of the other process.

global_uid does have thread-local protection, but (surprise) when ruby forks the parent's thread local storage is readable by the child.

```ruby
Thread.current[:foo] = "set in the parent"
puts "#{$$}: #{Thread.current.inspect}, #{Thread.current[:foo].inspect}"

fork do
  puts "#{$$}: #{Thread.current.inspect}, #{Thread.current[:foo].inspect}"
end
```

Output:

```
20256: #<Thread:0x007ffdc307f418 run>, "set in the parent"
20270: #<Thread:0x007ffdc307f418 run>, "set in the parent"
```

/cc @zendesk/infrastructure @libo @jacobat 