### PR TITLE
Clean up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 cache: bundler
 sudo: false
+before_install:
+  - gem update --system
+  - gem install bundler
 rvm:
-  - 2.2
   - 2.3
   - 2.4
+  - 2.5
 gemfile:
   - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.2.gemfile
@@ -12,13 +15,5 @@ gemfile:
   - gemfiles/rails5.2.gemfile
 bundler_args: --no-deployment
 script: "bundle exec rake test"
-matrix:
-  allow_failures:
-    - gemfile: gemfiles/rails5.2.gemfile
-  exclude:
-    - rvm: 2.4
-      gemfile: gemfiles/rails3.2.gemfile
-    - rvm: 2.4
-      gemfile: gemfiles/rails4.2.gemfile
 branches:
   only: master

--- a/README.md
+++ b/README.md
@@ -14,60 +14,56 @@ This gem only supports MySQL. Theoretically it should be easy to port it to othe
 
 ## Installation
 
-Shove this in your Gemfile and smoke it
+Add it to your gemfile and run `bundle install`:
 
-    gem "global_uid", :git => "git://github.com/zendesk/global_uid.git"
+```rb
+gem "global_uid"
+```
 
 ### Configuration
 
 First configure some databases in database.yml in the normal way.
 
-    id_server_1:
-      adapter: mysql2
-      host: id_server_db1.prod
-      port: 3306
+```yml
+id_server_1:
+  adapter: mysql2
+  host: id_server_db1.prod
+  port: 3306
 
-    id_server_2:
-        adapter: mysql2
-        host: id_server_db2.prod
-        port: 3306
+id_server_2:
+  adapter: mysql2
+  host: id_server_db2.prod
+  port: 3306
+```
 
 Then setup these servers, and other defaults in your environment.rb:
 
-    GlobalUid::Base.global_uid_options = {
-      :id_servers => [ 'id_server_1', 'id_server_2' ],
-      :increment_by => 3
-    }
+```rb
+GlobalUid::Base.global_uid_options = {
+  id_servers: [ 'id_server_1', 'id_server_2' ],
+  increment_by: 3
+}
+```
 
 Here's a complete list of the options you can use:
 
-    Name                  Default
-    :disabled             false                         
-            Disable GlobalUid entirely
-
-    :dry_run              false                         
-            Setting this parameter causes the REPLACE INTO statements to run, but the id picked up will not be used.
-
-    :connection_timeout   3 seconds                    
-            Timeout for connecting to a global UID server
-
-    :query_timeout        10 seconds                    
-            Timeout for retrieving a global UID from a server before we move on to the next server
-
-    :connection_retry     10.minutes
-            After failing to connect or query a UID server, how long before we retry
-
-    :notifier             A proc calling ActiveRecord::Base.logger
-            This proc is called with two parameters upon UID server failure -- an exception and a message
-
-    :increment_by         5
-            Chooses the step size for the increment.  This will define the maximum number of UID servers you can have.
+| Name                  | Default                                    | Description                                                                                                |
+| --------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `:disabled`           | `false`                                    | Disable GlobalUid entirely                                                                                 |
+| `:dry_run`            | `false`                                    | Setting this parameter causes the REPLACE INTO statements to run, but the id picked up will not be used.   |
+| `:connection_timeout` | 3 seconds                                  | Timeout for connecting to a global UID server                                                              |
+| `:query_timeout`      | 10 seconds                                 | Timeout for retrieving a global UID from a server before we move on to the next server                     |
+| `:connection_retry`   | 10 minutes                                 | After failing to connect or query a UID server, how long before we retry                                   |
+| `:notifier`           | A proc calling `ActiveRecord::Base.logger` | This proc is called with two parameters upon UID server failure -- an exception and a message              |
+| `:increment_by`       | 5                                          | Chooses the step size for the increment.  This will define the maximum number of UID servers you can have. |
 
 ### Testing
 
-    mysqladmin -uroot create global_uid_test
-    mysqladmin -uroot create global_uid_test_id_server_1
-    mysqladmin -uroot create global_uid_test_id_server_2
+```
+mysqladmin -uroot create global_uid_test
+mysqladmin -uroot create global_uid_test_id_server_1
+mysqladmin -uroot create global_uid_test_id_server_2
+```
 
 Copy test/config/database.yml.example to test/config/database.yml and make the modifications you need to point it to 2 local MySQL databases. Then +rake test+
 
@@ -78,10 +74,11 @@ your primary keys from signature "PRIMARY KEY AUTO_INCREMENT NOT NULL" to "PRIMA
 
 If you'd like to disable this behavior, you can write:
 
-    class CreateFoos < ActiveRecord::Migration
-      def self.up
-        create_table :foos, :use_global_uid => false do |t|
-
+```rb
+class CreateFoos < ActiveRecord::Migration
+  def self.up
+    create_table :foos, use_global_uid: false do |t|
+```
 
 ## Model-level stuff
 
@@ -92,27 +89,31 @@ It's the Rails way.
 
 ### Disabling global uid per table
 
-    class Foo < ActiveRecord::Base
-      disable_global_uid
-    end
+```rb
+class Foo < ActiveRecord::Base
+  disable_global_uid
+end
+````
 
 
 ## Taking matters into your own hands:
 
+```rb
+class Foo < ActiveRecord::Base
+  disable_global_uid
 
-	class Foo < ActiveRecord::Base
-		disable_global_uid
-
-		def before_create
-		  self.id = generate_uid()
-		  # other stuff
-		  ....
-		end
-
-	end
+  def before_create
+    self.id = generate_uid()
+    # other stuff
+    ....
+  end
+end
+```
 
 If you're using a non standard uid table then pass that in.
 
-    generate_uid(:uid_table => '<name>')
+```rb
+generate_uid(uid_table: '<name>')
+```
 
 Copyright (c) 2010 Zendesk, released under the MIT license

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ There are three parts to it: configuration, migration and object creation
 
 ### Interactions with other databases
 
-This plugin shouldn't fail with Databases other than MySQL but neither will it do anything either. There's theoretically nothing that should stop it from being *ported* to other DBs, we just don't need to.
+This gem only supports MySQL. Theoretically it should be easy to port it to other DBs, we just don't need to.
 
 ## Installation
 

--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -1,42 +1,44 @@
 PATH
   remote: ..
   specs:
-    global_uid (3.4.3)
+    global_uid (3.4.4)
       activerecord (>= 3.2.0, < 5.2)
       activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (3.2.18)
-      activesupport (= 3.2.18)
+    activemodel (3.2.22.5)
+      activesupport (= 3.2.22.5)
       builder (~> 3.0.0)
-    activerecord (3.2.18)
-      activemodel (= 3.2.18)
-      activesupport (= 3.2.18)
+    activerecord (3.2.22.5)
+      activemodel (= 3.2.22.5)
+      activesupport (= 3.2.22.5)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
-    activesupport (3.2.18)
+    activesupport (3.2.22.5)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     arel (3.0.3)
     builder (3.0.4)
-    bump (0.5.0)
-    i18n (0.6.9)
+    bump (0.6.0)
+    concurrent-ruby (1.0.5)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     metaclass (0.0.4)
     minitest (4.7.5)
     minitest-rg (1.1.1)
       minitest (< 5.0)
-    mocha (1.1.0)
+    mocha (1.5.0)
       metaclass (~> 0.0.1)
-    multi_json (1.10.1)
-    mysql2 (0.3.20)
-    phenix (0.2.0)
-      activerecord (>= 3.2, < 5.1)
+    multi_json (1.13.1)
+    mysql2 (0.3.21)
+    phenix (0.5.0)
+      activerecord (>= 3.2, < 6.0)
       bundler
-    rake (10.4.2)
-    tzinfo (0.3.39)
-    wwtd (0.5.3)
+    rake (12.3.1)
+    tzinfo (0.3.54)
+    wwtd (1.3.0)
 
 PLATFORMS
   ruby
@@ -55,4 +57,4 @@ DEPENDENCIES
   wwtd (>= 0.5.3)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     global_uid (3.4.4)
-      activerecord (>= 3.2.0, < 5.2)
+      activerecord (>= 3.2.0, < 6.0)
       activesupport
       mysql2
 

--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     global_uid (3.4.4)
       activerecord (>= 3.2.0, < 5.2)
       activesupport
+      mysql2
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec :path=>"../"
 
 gem "activerecord", "~> 4.2.0"
+gem "mysql2", ">= 0.3.13", "< 0.5"

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,46 +1,46 @@
 PATH
   remote: ..
   specs:
-    global_uid (3.4.3)
+    global_uid (3.4.4)
       activerecord (>= 3.2.0, < 5.2)
       activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.5)
-      activesupport (= 4.2.5)
+    activemodel (4.2.10)
+      activesupport (= 4.2.10)
       builder (~> 3.1)
-    activerecord (4.2.5)
-      activemodel (= 4.2.5)
-      activesupport (= 4.2.5)
+    activerecord (4.2.10)
+      activemodel (= 4.2.10)
+      activesupport (= 4.2.10)
       arel (~> 6.0)
-    activesupport (4.2.5)
+    activesupport (4.2.10)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    arel (6.0.3)
-    builder (3.2.2)
-    bump (0.5.3)
-    i18n (0.7.0)
-    json (1.8.3)
+    arel (6.0.4)
+    builder (3.2.3)
+    bump (0.6.0)
+    concurrent-ruby (1.0.5)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     metaclass (0.0.4)
-    minitest (5.8.3)
+    minitest (5.11.3)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
-    mocha (1.1.0)
+    mocha (1.5.0)
       metaclass (~> 0.0.1)
-    mysql2 (0.4.2)
-    phenix (0.2.0)
-      activerecord (>= 3.2, < 5.1)
+    mysql2 (0.4.10)
+    phenix (0.5.0)
+      activerecord (>= 3.2, < 6.0)
       bundler
-    rake (10.4.2)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    rake (12.3.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    wwtd (1.2.0)
+    wwtd (1.3.0)
 
 PLATFORMS
   ruby
@@ -53,10 +53,10 @@ DEPENDENCIES
   minitest
   minitest-rg
   mocha
-  mysql2
+  mysql2 (>= 0.3.13, < 0.5)
   phenix
   rake
   wwtd (>= 0.5.3)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     global_uid (3.4.4)
-      activerecord (>= 3.2.0, < 5.2)
+      activerecord (>= 3.2.0, < 6.0)
       activesupport
       mysql2
 

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     global_uid (3.4.4)
       activerecord (>= 3.2.0, < 5.2)
       activesupport
+      mysql2
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec :path=>"../"
 
 gem "activerecord", "5.0.0"
+gem "mysql2", ">= 0.3.18", "< 0.5"

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    global_uid (3.3.3)
-      activerecord (>= 3.2.0, < 5.1)
+    global_uid (3.4.4)
+      activerecord (>= 3.2.0, < 5.2)
       activesupport
 
 GEM
@@ -19,25 +19,26 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (7.0.0)
-    bump (0.5.3)
-    concurrent-ruby (1.0.2)
-    i18n (0.7.0)
+    arel (7.1.4)
+    bump (0.6.0)
+    concurrent-ruby (1.0.5)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     metaclass (0.0.4)
-    minitest (5.9.0)
+    minitest (5.11.3)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
-    mocha (1.1.0)
+    mocha (1.5.0)
       metaclass (~> 0.0.1)
-    mysql2 (0.4.2)
-    phenix (0.2.0)
-      activerecord (>= 3.2, < 5.1)
+    mysql2 (0.4.10)
+    phenix (0.5.0)
+      activerecord (>= 3.2, < 6.0)
       bundler
-    rake (10.4.2)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    rake (12.3.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    wwtd (1.2.0)
+    wwtd (1.3.0)
 
 PLATFORMS
   ruby
@@ -50,10 +51,10 @@ DEPENDENCIES
   minitest
   minitest-rg
   mocha
-  mysql2
+  mysql2 (>= 0.3.18, < 0.5)
   phenix
   rake
   wwtd (>= 0.5.3)
 
 BUNDLED WITH
-   1.12.5
+   1.16.1

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     global_uid (3.4.4)
-      activerecord (>= 3.2.0, < 5.2)
+      activerecord (>= 3.2.0, < 6.0)
       activesupport
       mysql2
 

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     global_uid (3.4.4)
       activerecord (>= 3.2.0, < 5.2)
       activesupport
+      mysql2
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '../'
 
 gem 'activerecord', '5.1.0'
+gem 'mysql2', '>= 0.3.18', '< 0.5'

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    global_uid (3.4.1)
+    global_uid (3.4.4)
       activerecord (>= 3.2.0, < 5.2)
       activesupport
 
@@ -20,22 +20,23 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (8.0.0)
-    bump (0.5.3)
+    bump (0.6.0)
     concurrent-ruby (1.0.5)
-    i18n (0.8.1)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     metaclass (0.0.4)
-    minitest (5.10.1)
+    minitest (5.11.3)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
-    mocha (1.2.1)
+    mocha (1.5.0)
       metaclass (~> 0.0.1)
-    mysql2 (0.4.6)
-    phenix (0.3.0)
-      activerecord (>= 3.2, < 5.2)
+    mysql2 (0.4.10)
+    phenix (0.5.0)
+      activerecord (>= 3.2, < 6.0)
       bundler
-    rake (12.0.0)
+    rake (12.3.1)
     thread_safe (0.3.6)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     wwtd (1.3.0)
 
@@ -50,10 +51,10 @@ DEPENDENCIES
   minitest
   minitest-rg
   mocha
-  mysql2
+  mysql2 (>= 0.3.18, < 0.5)
   phenix
   rake
   wwtd (>= 0.5.3)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     global_uid (3.4.4)
-      activerecord (>= 3.2.0, < 5.2)
+      activerecord (>= 3.2.0, < 6.0)
       activesupport
       mysql2
 

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     global_uid (3.4.4)
       activerecord (>= 3.2.0, < 5.2)
       activesupport
+      mysql2
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 5.2.0.beta1'
+gem 'activerecord', '~> 5.2.0'

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,42 +1,42 @@
 PATH
   remote: ..
   specs:
-    global_uid (3.4.3)
+    global_uid (3.4.4)
       activerecord (>= 3.2.0, < 5.2)
       activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.0.beta2)
-      activesupport (= 5.2.0.beta2)
-    activerecord (5.2.0.beta2)
-      activemodel (= 5.2.0.beta2)
-      activesupport (= 5.2.0.beta2)
+    activemodel (5.2.0.rc2)
+      activesupport (= 5.2.0.rc2)
+    activerecord (5.2.0.rc2)
+      activemodel (= 5.2.0.rc2)
+      activesupport (= 5.2.0.rc2)
       arel (>= 9.0)
-    activesupport (5.2.0.beta2)
+    activesupport (5.2.0.rc2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
-    bump (0.5.4)
+    bump (0.6.0)
     concurrent-ruby (1.0.5)
-    i18n (0.9.1)
+    i18n (1.0.0)
       concurrent-ruby (~> 1.0)
     metaclass (0.0.4)
-    minitest (5.10.3)
+    minitest (5.11.3)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
-    mocha (1.3.0)
+    mocha (1.5.0)
       metaclass (~> 0.0.1)
-    mysql2 (0.4.10)
-    phenix (0.4.0)
-      activerecord (>= 3.2, < 5.2)
+    mysql2 (0.5.1)
+    phenix (0.5.0)
+      activerecord (>= 3.2, < 6.0)
       bundler
-    rake (12.3.0)
+    rake (12.3.1)
     thread_safe (0.3.6)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     wwtd (1.3.0)
 
@@ -57,4 +57,4 @@ DEPENDENCIES
   wwtd (>= 0.5.3)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -2,20 +2,20 @@ PATH
   remote: ..
   specs:
     global_uid (3.4.4)
-      activerecord (>= 3.2.0, < 5.2)
+      activerecord (>= 3.2.0, < 6.0)
       activesupport
       mysql2
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.0.rc2)
-      activesupport (= 5.2.0.rc2)
-    activerecord (5.2.0.rc2)
-      activemodel (= 5.2.0.rc2)
-      activesupport (= 5.2.0.rc2)
+    activemodel (5.2.0)
+      activesupport (= 5.2.0)
+    activerecord (5.2.0)
+      activemodel (= 5.2.0)
+      activesupport (= 5.2.0)
       arel (>= 9.0)
-    activesupport (5.2.0.rc2)
+    activesupport (5.2.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -45,7 +45,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 5.2.0.beta1)
+  activerecord (~> 5.2.0)
   bump
   bundler
   global_uid!

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     global_uid (3.4.4)
       activerecord (>= 3.2.0, < 5.2)
       activesupport
+      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -51,7 +52,6 @@ DEPENDENCIES
   minitest
   minitest-rg
   mocha
-  mysql2
   phenix
   rake
   wwtd (>= 0.5.3)

--- a/global_uid.gemspec
+++ b/global_uid.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new 'global_uid', '3.4.4' do |s|
 
   s.add_dependency('activerecord', '>= 3.2.0', '< 5.2')
   s.add_dependency('activesupport')
+  s.add_dependency('mysql2')
 
-  s.add_development_dependency('mysql2')
   s.add_development_dependency('rake')
   s.add_development_dependency('bundler')
   s.add_development_dependency('minitest')

--- a/global_uid.gemspec
+++ b/global_uid.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new 'global_uid', '3.4.4' do |s|
 
   s.required_ruby_version = "~> 2.0"
 
-  s.add_dependency('activerecord', '>= 3.2.0', '< 5.2')
+  s.add_dependency('activerecord', '>= 3.2.0', '< 6.0')
   s.add_dependency('activesupport')
   s.add_dependency('mysql2')
 

--- a/global_uid.gemspec
+++ b/global_uid.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new 'global_uid', '3.4.4' do |s|
   s.homepage    = 'https://github.com/zendesk/global_uid'
   s.license     = "MIT"
 
-  s.required_ruby_version = "~> 2.0"
+  s.required_ruby_version = "~> 2.3"
 
   s.add_dependency('activerecord', '>= 3.2.0', '< 6.0')
   s.add_dependency('activesupport')

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -58,20 +58,17 @@ module GlobalUid
 
       raise "No global_uid support for adapter #{c[:adapter]}" if c[:adapter] != 'mysql2'
 
-      con = nil
       begin
         Timeout.timeout(connection_timeout, ConnectionTimeoutException) do
-          con = ActiveRecord::Base.mysql2_connection(config)
+          ActiveRecord::Base.mysql2_connection(config)
         end
       rescue ConnectionTimeoutException => e
         notify e, "Timed out establishing a connection to #{name}"
-        return nil
+        nil
       rescue Exception => e
         notify e, "establishing a connection to #{name}: #{e.message}"
-        return nil
+        nil
       end
-
-      con
     end
 
     def self.init_server_info(options)

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 require "active_record"
 require "active_support/all"
-
+require "mysql2"
 require "timeout"
-
-begin
-  require 'mysql2'
-rescue LoadError
-end
-
 
 module GlobalUid
   class Base
@@ -38,7 +32,6 @@ module GlobalUid
 
       engine_stmt = "ENGINE=#{global_uid_options[:storage_engine] || "MyISAM"}"
 
-      # TODO it would be nice to be able to set the engine or something to not be MySQL specific
       with_connections do |connection|
         connection.execute("CREATE TABLE IF NOT EXISTS `#{id_table_name}` (
         `id` #{type} NOT NULL AUTO_INCREMENT,
@@ -79,7 +72,7 @@ module GlobalUid
       con = nil
       begin
         GlobalUidTimer.timeout(connection_timeout, ConnectionTimeoutException) do
-          con = ActiveRecord::Base.send("#{c[:adapter]}_connection", config)
+          con = ActiveRecord::Base.mysql2_connection(config)
         end
       rescue ConnectionTimeoutException => e
         notify e, "Timed out establishing a connection to #{name}"


### PR DESCRIPTION
- Allow using Rails 5.2.
- Make a dependency on `mysql2`.
- Test with Ruby 2.5.
- Don’t use SystemTimer any more.

Depends on zendesk/phenix#9 and a new release of that gem.