### PR TITLE
Custom exceptions should inherit from StandardError

### DIFF
--- a/lib/global_uid.rb
+++ b/lib/global_uid.rb
@@ -6,9 +6,9 @@ require "global_uid/migration_extension"
 require "global_uid/schema_dumper_extension"
 
 module GlobalUid
-  class NoServersAvailableException < Exception ; end
-  class ConnectionTimeoutException < Exception ; end
-  class TimeoutException < Exception ; end
+  class NoServersAvailableException < StandardError ; end
+  class ConnectionTimeoutException < StandardError ; end
+  class TimeoutException < StandardError ; end
 
   autoload :ServerVariables, "global_uid/server_variables"
 end


### PR DESCRIPTION
General ruby convention is to not rescue `StandardError` but not `Exception`. By extension, custom errors should inherit from `StandardError`. The custom GlobalUid exceptions were not doing that. I don't see any reason why that's intentional.

I found myself in this situation because stock webrick (v1.4.2 / ruby v2.5.0), with RAILS_ENV=test, will return uncaught `Exception`s into 200s. Why? Beat's me! puma works fine. unicorn just crashes without a response.

cc @zendesk/cask @bquorning @grosser @staugaard @pschambacher

### Risks

Previously these exceptions would have been ignored by `StandardError` handlers. It may be surprising when these begin getting handled, but they should have been handled the entire time.