### PR TITLE
allow id column name to be specified as option in create_table

### DIFF
--- a/lib/global_uid/migration_extension.rb
+++ b/lib/global_uid/migration_extension.rb
@@ -8,15 +8,12 @@ module GlobalUid
       # rules for stripping out auto_increment -- enabled, not dry-run, and not a "PK-less" table
       remove_auto_increment = uid_enabled && !GlobalUid::Base.global_uid_options[:dry_run] && !(options[:id] == false)
 
-      if remove_auto_increment
-        old_id_option = options[:id]
-        options.merge!(:id => false)
-      end
+      options.merge!(:id => false) if remove_auto_increment
 
       super(name, options) { |t|
         if remove_auto_increment
           # need to honor specifically named tables
-          id_column_name = (old_id_option || :id)
+          id_column_name = options.fetch(:id_column_name, :id)
           t.column id_column_name, "int(10) NOT NULL PRIMARY KEY"
         end
         blk.call(t) if blk

--- a/test/global_uid_test.rb
+++ b/test/global_uid_test.rb
@@ -119,7 +119,7 @@ describe GlobalUid do
         end
       end
 
-      describe "with a named ID key" do
+      describe "with option :id_column_name" do
         before do
           CreateWithNamedID.up
         end

--- a/test/migrations.rb
+++ b/test/migrations.rb
@@ -38,7 +38,7 @@ class CreateWithNamedID < MigrationClass
   group :change if self.respond_to?(:group)
 
   def self.up
-    create_table :with_global_uids, :id => 'hello' do |t|
+    create_table :with_global_uids, :id_column_name => 'hello' do |t|
       t.string  :description
     end
   end


### PR DESCRIPTION
Currently database migrations run with active record 5.1 will fail to properly create a table with an `id` column. The issue is described in detail here: https://docs.google.com/document/d/1xfoTc62crUPMVZJi-9Q3mhOeJ4jngU5cqmnMviYwQMY/edit

Summary:

```ruby
class CreateRuleAttachment < ActiveRecord::Migration[5.0]
  project :zendesk

  shard :all
  group :before

  def change
    create_table :rule_attachments do |t|
  end
end
```

Result
```sql
CREATE TABLE `rule_attachments` (
  `integer` int(10) NOT NULL,
  PRIMARY KEY (`integer`)
)
```

What is the issue?
```
 `integer` int(10) NOT NULL
```
The primary key is getting created with the name of the data type instead of the column name.


To cover previous functionality that broke in AR5.1, we can allow the id column name to be specified as option in create_table by passing an option `:id_column_name` (previously `:id` could be used). I found no existing migrations that use this functionality, but possibly I missed some reference and this is useful functionality.
