### PR TITLE
remove named id column functionality that breaks in rails 5.1

### DIFF
--- a/lib/global_uid/migration_extension.rb
+++ b/lib/global_uid/migration_extension.rb
@@ -8,17 +8,10 @@ module GlobalUid
       # rules for stripping out auto_increment -- enabled, not dry-run, and not a "PK-less" table
       remove_auto_increment = uid_enabled && !GlobalUid::Base.global_uid_options[:dry_run] && !(options[:id] == false)
 
-      if remove_auto_increment
-        old_id_option = options[:id]
-        options.merge!(:id => false)
-      end
+      options.merge!(:id => false) if remove_auto_increment
 
       super(name, options) { |t|
-        if remove_auto_increment
-          # need to honor specifically named tables
-          id_column_name = (old_id_option || :id)
-          t.column id_column_name, "int(10) NOT NULL PRIMARY KEY"
-        end
+        t.column :id, "int(10) NOT NULL PRIMARY KEY" if remove_auto_increment
         blk.call(t) if blk
       }
 

--- a/test/global_uid_test.rb
+++ b/test/global_uid_test.rb
@@ -118,22 +118,6 @@ describe GlobalUid do
           CreateWithNoParams.down
         end
       end
-
-      describe "with a named ID key" do
-        before do
-          CreateWithNamedID.up
-        end
-
-        it "preserve the name of the ID key" do
-          @create_table = show_create_sql(WithGlobalUID, "with_global_uids").split("\n")
-          assert(@create_table.grep(/hello.*int/i))
-          assert(@create_table.grep(/primary key.*hello/i))
-        end
-
-        after do
-          CreateWithNamedID.down
-        end
-      end
     end
 
     describe "with :use_global_uid => true" do

--- a/test/migrations.rb
+++ b/test/migrations.rb
@@ -34,20 +34,6 @@ class CreateWithExplicitUidTrue < MigrationClass
   end
 end
 
-class CreateWithNamedID < MigrationClass
-  group :change if self.respond_to?(:group)
-
-  def self.up
-    create_table :with_global_uids, :id => 'hello' do |t|
-      t.string  :description
-    end
-  end
-
-  def self.down
-    drop_table :with_global_uids
-  end
-end
-
 class CreateWithoutGlobalUIDs < MigrationClass
   group :change if self.respond_to?(:group)
 


### PR DESCRIPTION
Currently database migrations run with active record 5.1 will fail to properly create a table with an `id` column. 

Summary:

```
class CreateMyRecords < ActiveRecord::Migration[5.0]
  def change
    create_table :my_records do |t|
  end
end
```

Result
```
CREATE TABLE `my_records` (
  `integer` int(10) NOT NULL,
  PRIMARY KEY (`integer`)
)
```

What is the issue?
 `integer` int(10) NOT NULL
The primary key is getting created with the name of the data type instead of the column name.


This PR removes functionality that broke in AR5.1, which previously allowed a user to specify the id column name. This does not appear to be in use at Zendesk.
