### PR TITLE
auto_increment_increment validation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+- [Breaking change] ID Validation, ensure the ID coming back has been incremented using the configured `auto_increment_increment`. (https://github.com/zendesk/global_uid/pull/63)
+
 ### Removed
 - Removed the `dry_run` option (https://github.com/zendesk/global_uid/pull/64)
 - Removed `GlobalUid::ServerVariables` module (https://github.com/zendesk/global_uid/pull/66)

--- a/README.md
+++ b/README.md
@@ -49,14 +49,15 @@ The `increment_by` value configured here does not dictate the value on your allo
 
 Here's a complete list of the options you can use:
 
-| Name                  | Default                                    | Description                                                                                                |
-| --------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| `:disabled`           | `false`                                    | Disable GlobalUid entirely                                                                                 |
-| `:connection_timeout` | 3 seconds                                  | Timeout for connecting to a global UID server                                                              |
-| `:query_timeout`      | 10 seconds                                 | Timeout for retrieving a global UID from a server before we move on to the next server                     |
-| `:connection_retry`   | 10 minutes                                 | After failing to connect or query a UID server, how long before we retry                                   |
-| `:notifier`           | A proc calling `ActiveRecord::Base.logger` | This proc is called with two parameters upon UID server failure -- an exception and a message              |
-| `:increment_by`       | 5                                          | Used to validate number of ID servers, preventing connections if there are more servers than the given increment |
+| Name                             | Default                                    | Description                                                                                                  |
+| -------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `:disabled`                      | `false`                                    | Disable GlobalUid entirely                                                                                   |
+| `:connection_timeout`            | 3 seconds                                  | Timeout for connecting to a global UID server                                                                |
+| `:query_timeout`                 | 10 seconds                                 | Timeout for retrieving a global UID from a server before we move on to the next server                       |
+| `:connection_retry`              | 10 minutes                                 | After failing to connect or query a UID server, how long before we retry                                     |
+| `:notifier`                      | A proc calling `ActiveRecord::Base.logger` | This proc is called with two parameters upon UID server failure -- an exception and a message                |
+| `:increment_by`                  | 5                                          | Used for validation, compared with the value on the alloc servers to prevent allocation of duplicate IDs     |
+| `:suppress_increment_exceptions` | `false`                                    | Suppress configuration validation, allowing updates to `auto_increment_increment` while alloc servers in use |
 
 ### Migration
 

--- a/lib/global_uid.rb
+++ b/lib/global_uid.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "global_uid/base"
+require "global_uid/allocator"
 require "global_uid/active_record_extension"
 require "global_uid/has_and_belongs_to_many_builder_extension"
 require "global_uid/migration_extension"
@@ -9,6 +10,7 @@ module GlobalUid
   class NoServersAvailableException < StandardError ; end
   class ConnectionTimeoutException < StandardError ; end
   class TimeoutException < StandardError ; end
+  class InvalidIncrementException < StandardError ; end
 end
 
 ActiveRecord::Base.send(:include, GlobalUid::ActiveRecordExtension)

--- a/lib/global_uid/allocator.rb
+++ b/lib/global_uid/allocator.rb
@@ -1,0 +1,67 @@
+module GlobalUid
+  class Allocator
+    attr_reader :recent_allocations, :max_window_size, :incrementing_by, :connection
+
+    def initialize(incrementing_by:, connection:)
+      @recent_allocations = []
+      @max_window_size = 5
+      @incrementing_by = incrementing_by
+      @connection = connection
+      validate_connection_increment
+    end
+
+    def allocate_one(table)
+      identifier = connection.insert("REPLACE INTO #{table} (stub) VALUES ('a')")
+      allocate(identifier)
+    end
+
+    def allocate_many(table, count:)
+      increment_by = validate_connection_increment
+
+      start_id = connection.insert("REPLACE INTO #{table} (stub) VALUES " + (["('a')"] * count).join(','))
+      identifiers = start_id.step(start_id + (count - 1) * increment_by, increment_by).to_a
+      identifiers.each { |identifier| allocate(identifier) }
+      identifiers
+    end
+
+    private
+
+    def allocate(identifier)
+      recent_allocations.shift if recent_allocations.size >= max_window_size
+      recent_allocations << identifier
+
+      if !valid_allocation?
+        db_increment = connection.select_value("SELECT @@auto_increment_increment")
+        message = "Configured: '#{incrementing_by}', Found: '#{db_increment}' on '#{connection.current_database}'. Recently allocated IDs: #{recent_allocations}"
+        alert(InvalidIncrementException.new(message))
+      end
+
+      identifier
+    end
+
+    def valid_allocation?
+      recent_allocations[1..-1].all? do |identifier|
+        (identifier > recent_allocations[0]) &&
+          (identifier - recent_allocations[0]) % incrementing_by == 0
+      end
+    end
+
+    def validate_connection_increment
+      db_increment = connection.select_value("SELECT @@auto_increment_increment")
+
+      if db_increment != incrementing_by
+        alert(InvalidIncrementException.new("Configured: '#{incrementing_by}', Found: '#{db_increment}' on '#{connection.current_database}'"))
+      end
+
+      db_increment
+    end
+
+    def alert(exception)
+      if GlobalUid::Base.global_uid_options[:suppress_increment_exceptions]
+        GlobalUid::Base.notify(exception, exception.message)
+      else
+        raise exception
+      end
+    end
+  end
+end

--- a/test/lib/allocator_test.rb
+++ b/test/lib/allocator_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+describe GlobalUid::Allocator do
+  let(:connection)   { mock('connection') }
+  let(:increment_by) { 10 }
+  let(:allocator)    { GlobalUid::Allocator.new(incrementing_by: increment_by, connection: connection) }
+  let(:table)        { mock('table_class').class }
+
+  before do
+    restore_defaults!
+    connection.stubs(:current_database).returns('database_name')
+  end
+
+  describe 'with a configured increment_by that differs from the connections auto_increment_increment' do
+    it 'raises an exception to prevent erroneous ID allocation' do
+      connection.stubs(:select_value).with('SELECT @@auto_increment_increment').returns(50)
+      exception = assert_raises(GlobalUid::InvalidIncrementException) do
+        GlobalUid::Allocator.new(incrementing_by: 10, connection: connection)
+      end
+
+      assert_equal("Configured: '10', Found: '50' on 'database_name'", exception.message)
+    end
+  end
+
+  describe 'with a configured increment_by that matches the connections auto_increment_increment' do
+    before do
+      connection.stubs(:select_value).with('SELECT @@auto_increment_increment').returns(increment_by)
+    end
+
+    describe '#allocate_one' do
+      it 'allocates IDs, maintaining a small rolling selection of IDs for comparison' do
+        [10, 20, 30, 40, 50, 60, 70, 80].each do |id|
+          connection.expects(:insert).returns(id)
+          allocator.allocate_one(table)
+        end
+
+        assert_equal(5, allocator.max_window_size)
+        assert_equal([40, 50, 60, 70, 80], allocator.recent_allocations)
+      end
+
+      describe 'gap between ID not divisible by increment_by' do
+        it 'raises an error' do
+          connection.expects(:insert).returns(20)
+          allocator.allocate_one(table)
+
+          connection.stubs(:select_value).with('SELECT @@auto_increment_increment').returns(5)
+          connection.expects(:insert).returns(25)
+          exception = assert_raises(GlobalUid::InvalidIncrementException) do
+            allocator.allocate_one(table)
+          end
+
+          assert_equal("Configured: '10', Found: '5' on 'database_name'. Recently allocated IDs: [20, 25]", exception.message)
+        end
+      end
+
+      describe 'ID value does not increment upwards' do
+        it 'raises an error' do
+          connection.expects(:insert).returns(20)
+          allocator.allocate_one(table)
+
+          connection.expects(:insert).returns(20 - increment_by)
+          exception = assert_raises(GlobalUid::InvalidIncrementException) do
+            allocator.allocate_one(table)
+          end
+
+          assert_equal("Configured: '10', Found: '10' on 'database_name'. Recently allocated IDs: [20, 10]", exception.message)
+        end
+      end
+    end
+
+    describe '#allocate_many' do
+      it 'allocates IDs, maintaining a small rolling selection of IDs for comparison' do
+        connection.expects(:insert)
+          .with("REPLACE INTO Mocha::Mock (stub) VALUES ('a'),('a'),('a'),('a'),('a'),('a'),('a'),('a')")
+          .returns(10)
+        allocator.allocate_many(table, count: 8)
+
+        assert_equal(5, allocator.max_window_size)
+        assert_equal([40, 50, 60, 70, 80], allocator.recent_allocations)
+      end
+
+      describe 'with a configured increment_by that differs from the active connection auto_increment_increment' do
+        it 'raises an error' do
+          connection.stubs(:select_value).with('SELECT @@auto_increment_increment').returns(5)
+          connection.expects(:insert).never
+          exception = assert_raises(GlobalUid::InvalidIncrementException) do
+            allocator.allocate_many(table, count: 8)
+          end
+
+          assert_equal("Configured: '10', Found: '5' on 'database_name'", exception.message)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch adds `auto_increment_increment` validation to the following scenarios:
 * Connection initialization
 * Allocating one ID
 * Allocating multiple IDs

A lot of refactoring was done as part of this PR and has either been merged separately or moved to https://github.com/zendesk/global_uid/pull/70

These changes have been benchmarked, should have no noticeable impact to performance and continue to be thread safe.

Validation during initialization is done by comparing the client configuration (`increment_by`) with each alloc server (`auto_increment_increment`). If the server is misconfigured, an error is reported via the `notifier` (defaults to error logs) and it's removed from the pool. The connection will be retried every 10 minutes (configurable via the `connection_retry`) indefinitely.

Validation during allocation happens by storing the ID returned and comparing it with the last 4 identifiers, ensuring they've been incremented correctly by the configured amount. The alloc servers are shared and there's no guarantee that the process will get the next increment. As an example, one process (think unicorn worker or puma thread) may receive 5, 15, 25 while the other received 10 & 20. This is why we validate by checking the remained. This will not raise an error if the `auto_increment_increment` [increases by a factor of 2.](https://github.com/zendesk/global_uid/pull/63/files#diff-a80d8acc12753fc7a764c5990a567195R335)

If the `auto_increment_increment` changes while the clients are using the server, the alloc server is removed from the list of servers and an error is reported via the `notifier`. The server is retried after a minute, indefinitely.

An exception is raised and ID allocation ceases if all servers are misconfigured. This will result in the process raising a `NoServersAvailableException` exception and halting. New unicorns or puma threads will attempt to connect each time they are spawned.

To support valid updates to the `auto_increment_increment` on active alloc servers, the `suppress_increment_exceptions` option can be used to swallow the exceptions and call the notifier. This will allow those who have monitors configured to be notified of the change and also allow the servers to remain in use while the update is being performed.
