### PR TITLE
Remove the concept of `dry_run`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Removed
+- Removed the `dry_run` option (https://github.com/zendesk/global_uid/pull/64)
+
 ## [3.7.1] - 2020-02-06
 ### Added
 - Support for Rails 6.0. (https://github.com/zendesk/global_uid/pull/60)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Here's a complete list of the options you can use:
 | Name                  | Default                                    | Description                                                                                                |
 | --------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
 | `:disabled`           | `false`                                    | Disable GlobalUid entirely                                                                                 |
-| `:dry_run`            | `false`                                    | Setting this parameter causes the REPLACE INTO statements to run, but the id picked up will not be used.   |
 | `:connection_timeout` | 3 seconds                                  | Timeout for connecting to a global UID server                                                              |
 | `:query_timeout`      | 10 seconds                                 | Timeout for retrieving a global UID from a server before we move on to the next server                     |
 | `:connection_retry`   | 10 minutes                                 | After failing to connect or query a UID server, how long before we retry                                   |

--- a/lib/global_uid/active_record_extension.rb
+++ b/lib/global_uid/active_record_extension.rb
@@ -11,17 +11,7 @@ module GlobalUid
       return if GlobalUid::Base.global_uid_options[:disabled]
       return if self.class.global_uid_disabled
 
-      global_uid = nil
-      realtime = Benchmark::realtime do
-        global_uid = self.class.generate_uid
-      end
-
-      if GlobalUid::Base.global_uid_options[:dry_run]
-        ActiveRecord::Base.logger.info("GlobalUid dry-run: #{self.class.name}\t#{global_uid}\t#{"%.4f" % realtime}")
-        return
-      end
-
-      self.id = global_uid
+      self.id = self.class.generate_uid
     end
 
     module ClassMethods

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -13,8 +13,7 @@ module GlobalUid
       :query_timeout        => 10,
       :increment_by         => 5,  # This will define the maximum number of servers that you can have
       :disabled             => false,
-      :per_process_affinity => true,
-      :dry_run              => false
+      :per_process_affinity => true
     }
 
     def self.servers

--- a/lib/global_uid/migration_extension.rb
+++ b/lib/global_uid/migration_extension.rb
@@ -5,8 +5,8 @@ module GlobalUid
     def create_table(name, options = {}, &blk)
       uid_enabled = !(GlobalUid::Base.global_uid_options[:disabled] || options[:use_global_uid] == false)
 
-      # rules for stripping out auto_increment -- enabled, not dry-run, and not a "PK-less" table
-      remove_auto_increment = uid_enabled && !GlobalUid::Base.global_uid_options[:dry_run] && !(options[:id] == false)
+      # rules for stripping out auto_increment -- enabled and not a "PK-less" table
+      remove_auto_increment = uid_enabled && !(options[:id] == false)
 
       options.merge!(:id => false) if remove_auto_increment
 

--- a/test/global_uid_test.rb
+++ b/test/global_uid_test.rb
@@ -328,34 +328,6 @@ describe GlobalUid do
     end
   end
 
-  describe "In dry-run mode" do
-    before do
-      GlobalUid::Base.global_uid_options[:dry_run] = true
-      CreateWithNoParams.up
-    end
-
-    it "increment normally1" do
-      (1..10).each do |i|
-        assert_equal i, WithGlobalUID.create!.id
-      end
-    end
-
-    it "insert into the UID servers nonetheless" do
-      GlobalUid::Base.expects(:get_uid_for_class).at_least(10)
-      10.times { WithGlobalUID.create! }
-    end
-
-    it "log the results" do
-      ActiveRecord::Base.logger.expects(:info).at_least(10)
-      10.times { WithGlobalUID.create! }
-    end
-
-    after do
-      reset_connections!
-      CreateWithNoParams.down
-    end
-  end
-
   describe "with forking" do
     def parent_child_fork_values
       IO.pipe do |read_pipe, write_pipe|
@@ -441,7 +413,6 @@ describe GlobalUid do
   def restore_defaults!
     GlobalUid::Base.global_uid_options[:storage_engine] = nil
     GlobalUid::Base.global_uid_options[:disabled] = false
-    GlobalUid::Base.global_uid_options[:dry_run] = false
   end
 
   def show_create_sql(klass, table)


### PR DESCRIPTION
The flag was false by default. It adds complexity to the code and can be confused with the other disabled states `use_global_uid`, the `global_uid_options[:disabled]` option and `global_uid_disabled` on the model.

Use `global_uid_options[:disabled]` if you want to disable the functionality. There's a performance spec for benchmarking included in dc1f998