### PR TITLE
Move alloc connection handling into new GlobalUid::Server class 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,11 +8,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 - [Breaking change] ID Validation, ensure the ID coming back has been incremented using the configured `auto_increment_increment`. (https://github.com/zendesk/global_uid/pull/63)
+- `notify` is called before raising `NoServersAvailableException` (https://github.com/zendesk/global_uid/pull/71)
+
+### Changed
+- `with_connections` has been replaced by `with_servers` which contains the connection metadata (increment_by, timeout, allocations, etc) (https://github.com/zendesk/global_uid/pull/71)
 
 ### Removed
 - Removed the `dry_run` option (https://github.com/zendesk/global_uid/pull/64)
 - Removed `GlobalUid::ServerVariables` module (https://github.com/zendesk/global_uid/pull/66)
 - Removed `options` parameter from `generate_uid` & `generate_many_uids` (https://github.com/zendesk/global_uid/pull/68)
+- The following methods on `GlobalUid::Base` are no longer accessible as they're for internal use only (https://github.com/zendesk/global_uid/pull/71)
+  - `GlobalUid::Base.setup_connections!`
+  - `GlobalUid::Base.get_uid_for_class`
+  - `GlobalUid::Base.get_many_uids_for_class`
+  - `GlobalUid::Base.create_uid_tables`
+  - `GlobalUid::Base.drop_uid_tables`
+  - `GlobalUid::Base.get_connections`
 
 ## [3.7.1] - 2020-02-06
 ### Added

--- a/lib/global_uid.rb
+++ b/lib/global_uid.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "global_uid/base"
 require "global_uid/allocator"
+require "global_uid/server"
 require "global_uid/active_record_extension"
 require "global_uid/has_and_belongs_to_many_builder_extension"
 require "global_uid/migration_extension"

--- a/lib/global_uid/active_record_extension.rb
+++ b/lib/global_uid/active_record_extension.rb
@@ -28,11 +28,15 @@ module GlobalUid
       end
 
       def generate_uid
-        GlobalUid::Base.get_uid_for_class(self)
+        GlobalUid::Base.with_servers do |server|
+          return server.allocate(self)
+        end
       end
 
       def generate_many_uids(count)
-        GlobalUid::Base.get_many_uids_for_class(self, count)
+        GlobalUid::Base.with_servers do |server|
+          return server.allocate(self, count: count)
+        end
       end
 
       def disable_global_uid

--- a/lib/global_uid/allocator.rb
+++ b/lib/global_uid/allocator.rb
@@ -16,6 +16,8 @@ module GlobalUid
     end
 
     def allocate_many(table, count:)
+      return [] unless count > 0
+
       increment_by = validate_connection_increment
 
       start_id = connection.insert("REPLACE INTO #{table} (stub) VALUES " + (["('a')"] * count).join(','))

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -102,7 +102,6 @@ module GlobalUid
     end
 
     def self.get_many_uids_for_class(klass, count)
-      return [] unless count > 0
       with_servers do |server|
         Timeout.timeout(self.global_uid_options[:query_timeout], TimeoutException) do
           return server.allocator.allocate_many(klass.global_uid_table, count: count)

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -91,11 +91,6 @@ module GlobalUid
       end
     end
 
-    def self.connections
-      return [] if servers.nil?
-      servers.select(&:active?).map(&:connection)
-    end
-
     def self.global_uid_options=(options)
       @global_uid_options = GLOBAL_UID_DEFAULTS.merge(options.symbolize_keys)
     end

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -79,7 +79,9 @@ module GlobalUid
           server.update_retry_at(0)
         end
         message = errors.empty? ? "" : "Errors hit: #{errors.map(&:to_s).join(', ')}"
-        raise NoServersAvailableException.new(message)
+        exception = NoServersAvailableException.new(message)
+        notify(exception, message)
+        raise exception
       end
 
       servers

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -113,8 +113,9 @@ module GlobalUid
       end
     end
 
-    def self.get_connections
-      with_connections {}
+    def self.connections
+      return [] if servers.nil?
+      servers.map(&:connection).compact
     end
 
     def self.get_uid_for_class(klass)

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -92,9 +92,7 @@ module GlobalUid
       increment_by = self.global_uid_options[:increment_by]
 
       if self.servers.nil?
-        self.servers = init_server_info
-        # sorting here sets up each process to have affinity to a particular server.
-        self.servers = self.servers.sort_by { |server| server.rand }
+        self.servers = init_server_info.shuffle
       end
 
       self.servers.each do |server|
@@ -123,10 +121,7 @@ module GlobalUid
 
     def self.with_connections
       servers = setup_connections!
-
-      if !self.global_uid_options[:per_process_affinity]
-        servers = servers.sort_by { rand } #yes, I know it's not true random.
-      end
+      servers = servers.shuffle if !self.global_uid_options[:per_process_affinity]
 
       raise NoServersAvailableException if servers.empty?
 

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -96,18 +96,6 @@ module GlobalUid
       servers.select(&:active?).map(&:connection)
     end
 
-    def self.get_uid_for_class(klass)
-      with_servers do |server|
-        return server.allocate(klass)
-      end
-    end
-
-    def self.get_many_uids_for_class(klass, count)
-      with_servers do |server|
-        return server.allocate(klass, count: count)
-      end
-    end
-
     def self.global_uid_options=(options)
       @global_uid_options = GLOBAL_UID_DEFAULTS.merge(options.symbolize_keys)
     end

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -99,7 +99,6 @@ module GlobalUid
           return server.allocator.allocate_one(klass.global_uid_table)
         end
       end
-      raise NoServersAvailableException, "All global UID servers are gone!"
     end
 
     def self.get_many_uids_for_class(klass, count)
@@ -109,7 +108,6 @@ module GlobalUid
           return server.allocator.allocate_many(klass.global_uid_table, count: count)
         end
       end
-      raise NoServersAvailableException, "All global UID servers are gone!"
     end
 
     def self.global_uid_options=(options)

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -49,14 +49,10 @@ module GlobalUid
       self.servers = nil
     end
 
-    def self.setup_connections!
-      self.servers ||= init_server_info.shuffle
-      self.servers.each(&:connect)
-    end
-
     def self.with_servers
-      servers = setup_connections!
-      servers = servers.shuffle if !self.global_uid_options[:per_process_affinity]
+      self.servers ||= init_server_info.shuffle
+      servers = self.servers.each(&:connect)
+      servers.shuffle! if !self.global_uid_options[:per_process_affinity]
 
       errors = []
       servers.each do |server|

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -51,26 +51,6 @@ module GlobalUid
       end
     end
 
-    def self.new_connection(name, connection_timeout)
-      raise "No id server '#{name}' configured in database.yml" unless ActiveRecord::Base.configurations.to_h.has_key?(name)
-      config = ActiveRecord::Base.configurations.to_h[name]
-      c = config.symbolize_keys
-
-      raise "No global_uid support for adapter #{c[:adapter]}" if c[:adapter] != 'mysql2'
-
-      begin
-        Timeout.timeout(connection_timeout, ConnectionTimeoutException) do
-          ActiveRecord::Base.mysql2_connection(config)
-        end
-      rescue ConnectionTimeoutException => e
-        notify e, "Timed out establishing a connection to #{name}"
-        nil
-      rescue Exception => e
-        notify e, "establishing a connection to #{name}: #{e.message}"
-        nil
-      end
-    end
-
     def self.init_server_info
       id_servers = self.global_uid_servers
       increment_by = self.global_uid_options[:increment_by]

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -26,31 +26,6 @@ module GlobalUid
       Thread.current["global_uid_servers_#{$$}"] = s
     end
 
-    def self.create_uid_tables(id_table_name, options={})
-      type     = options[:uid_type] || "bigint(21) UNSIGNED"
-      start_id = options[:start_id] || 1
-
-      engine_stmt = "ENGINE=#{global_uid_options[:storage_engine] || "MyISAM"}"
-
-      with_servers do |server|
-        server.connection.execute("CREATE TABLE IF NOT EXISTS `#{id_table_name}` (
-        `id` #{type} NOT NULL AUTO_INCREMENT,
-        `stub` char(1) NOT NULL DEFAULT '',
-        PRIMARY KEY (`id`),
-        UNIQUE KEY `stub` (`stub`)
-        ) #{engine_stmt}")
-
-        # prime the pump on each server
-        server.connection.execute("INSERT IGNORE INTO `#{id_table_name}` VALUES(#{start_id}, 'a')")
-      end
-    end
-
-    def self.drop_uid_tables(id_table_name)
-      with_servers do |server|
-        server.connection.execute("DROP TABLE IF EXISTS `#{id_table_name}`")
-      end
-    end
-
     def self.init_server_info
       id_servers = self.global_uid_servers
       increment_by = self.global_uid_options[:increment_by]

--- a/lib/global_uid/migration_extension.rb
+++ b/lib/global_uid/migration_extension.rb
@@ -17,7 +17,14 @@ module GlobalUid
 
       if uid_enabled
         id_table_name = options[:global_uid_table] || GlobalUid::Base.id_table_from_name(name)
-        GlobalUid::Base.create_uid_tables(id_table_name, options)
+        GlobalUid::Base.with_servers do |server|
+          server.create_uid_table!(
+            name: id_table_name,
+            uid_type: options[:uid_type] || "bigint(21) UNSIGNED",
+            start_id: options[:start_id] || 1,
+            storage_engine: GlobalUid::Base.global_uid_options[:storage_engine] || "MyISAM"
+          )
+        end
       end
 
     end
@@ -25,7 +32,9 @@ module GlobalUid
     def drop_table(name, options = {})
       if !GlobalUid::Base.global_uid_options[:disabled] && options[:use_global_uid] == true
         id_table_name = options[:global_uid_table] || GlobalUid::Base.id_table_from_name(name)
-        GlobalUid::Base.drop_uid_tables(id_table_name)
+        GlobalUid::Base.with_servers do |server|
+          server.drop_uid_table!(name: id_table_name)
+        end
       end
       super(name, options)
     end

--- a/lib/global_uid/server.rb
+++ b/lib/global_uid/server.rb
@@ -50,17 +50,15 @@ module GlobalUid
 
       raise "No global_uid support for adapter #{c[:adapter]}" if c[:adapter] != 'mysql2'
 
-      begin
-        Timeout.timeout(connection_timeout, ConnectionTimeoutException) do
-          ActiveRecord::Base.mysql2_connection(config)
-        end
-      rescue ConnectionTimeoutException => e
-        GlobalUid::Base.notify e, "Timed out establishing a connection to #{name}"
-        nil
-      rescue Exception => e
-        GlobalUid::Base.notify e, "establishing a connection to #{name}: #{e.message}"
-        nil
+      Timeout.timeout(connection_timeout, ConnectionTimeoutException) do
+        ActiveRecord::Base.mysql2_connection(config)
       end
+    rescue ConnectionTimeoutException => e
+      GlobalUid::Base.notify e, "Timed out establishing a connection to #{name}"
+      nil
+    rescue Exception => e
+      GlobalUid::Base.notify e, "establishing a connection to #{name}: #{e.message}"
+      nil
     end
 
   end

--- a/lib/global_uid/server.rb
+++ b/lib/global_uid/server.rb
@@ -44,6 +44,22 @@ module GlobalUid
       @allocator = nil
     end
 
+    def create_uid_table!(name:, uid_type:, start_id:, storage_engine:)
+      connection.execute("CREATE TABLE IF NOT EXISTS `#{name}` (
+      `id` #{uid_type} NOT NULL AUTO_INCREMENT,
+      `stub` char(1) NOT NULL DEFAULT '',
+      PRIMARY KEY (`id`),
+      UNIQUE KEY `stub` (`stub`)
+      ) ENGINE=#{storage_engine}")
+
+      # prime the pump on each server
+      connection.execute("INSERT IGNORE INTO `#{name}` VALUES(#{start_id}, 'a')")
+    end
+
+    def drop_uid_table!(name:)
+      connection.execute("DROP TABLE IF EXISTS `#{name}`")
+    end
+
     private
 
     attr_accessor :connection_retry, :connection_timeout, :retry_at, :increment_by

--- a/lib/global_uid/server.rb
+++ b/lib/global_uid/server.rb
@@ -1,15 +1,43 @@
 module GlobalUid
   class Server
 
-    attr_accessor :connection, :name, :retry_at, :new, :allocator
+    attr_accessor :connection, :name, :retry_at, :new, :allocator, :increment_by
 
-    def initialize(name)
+    def initialize(name, increment_by: , connection_retry:, connection_timeout:)
       @connection = nil
       @name      = name
       @retry_at  = nil
       @new       = true
       @allocator = nil
+      @increment_by = increment_by
+      @connection_retry = connection_retry
+      @connection_timeout = connection_timeout
     end
+
+    def connect
+      return unless connection.nil?
+
+      if new? || ( retry_at && Time.now > retry_at )
+        @new = false
+
+        begin
+          @connection = GlobalUid::Base.new_connection(name, connection_timeout)
+
+          if @connection.nil?
+            @retry_at = Time.now + connection_retry
+          else
+            @allocator = Allocator.new(incrementing_by: increment_by, connection: @connection)
+          end
+        rescue InvalidIncrementException => e
+          GlobalUid::Base.notify e, "#{e.message}"
+          @connection = nil
+        end
+      end
+    end
+
+    private
+
+    attr_accessor :connection_retry, :connection_timeout
 
     def new?
       @new

--- a/lib/global_uid/server.rb
+++ b/lib/global_uid/server.rb
@@ -1,0 +1,20 @@
+module GlobalUid
+  class Server
+
+    attr_accessor :cx, :name, :retry_at, :rand, :new, :allocator
+
+    def initialize(name)
+      @cx        = nil
+      @name      = name
+      @retry_at  = nil
+      @rand      = rand
+      @new       = true
+      @allocator = nil
+    end
+
+    def new?
+      @new
+    end
+
+  end
+end

--- a/lib/global_uid/server.rb
+++ b/lib/global_uid/server.rb
@@ -1,10 +1,10 @@
 module GlobalUid
   class Server
 
-    attr_accessor :cx, :name, :retry_at, :new, :allocator
+    attr_accessor :connection, :name, :retry_at, :new, :allocator
 
     def initialize(name)
-      @cx        = nil
+      @connection = nil
       @name      = name
       @retry_at  = nil
       @new       = true

--- a/lib/global_uid/server.rb
+++ b/lib/global_uid/server.rb
@@ -1,13 +1,12 @@
 module GlobalUid
   class Server
 
-    attr_accessor :cx, :name, :retry_at, :rand, :new, :allocator
+    attr_accessor :cx, :name, :retry_at, :new, :allocator
 
     def initialize(name)
       @cx        = nil
       @name      = name
       @retry_at  = nil
-      @rand      = rand
       @new       = true
       @allocator = nil
     end

--- a/test/lib/global_uid_test.rb
+++ b/test/lib/global_uid_test.rb
@@ -508,8 +508,10 @@ describe GlobalUid do
     end
 
     it "creates new MySQL connections" do
-      # Ensure the parent has a connection
-      refute_empty GlobalUid::Base.setup_connections!
+      GlobalUid::Base.with_servers do |_server|
+        # Ensure the parent has a connection
+      end
+
       parent_value, child_value = parent_child_fork_values { GlobalUid::Base.connections.map(&:object_id) }
       refute_equal child_value, parent_value
     end

--- a/test/lib/global_uid_test.rb
+++ b/test/lib/global_uid_test.rb
@@ -5,11 +5,11 @@ describe GlobalUid do
   before do
     Phenix.rise!(with_schema: false)
     ActiveRecord::Base.establish_connection(:test)
-    reset_connections!
     restore_defaults!
   end
 
   after do
+    GlobalUid::Base.disconnect!
     Phenix.burn!
   end
 
@@ -208,7 +208,6 @@ describe GlobalUid do
     end
 
     after do
-      reset_connections!
       CreateWithNoParams.down
       CreateWithoutGlobalUIDs.down
     end
@@ -271,7 +270,6 @@ describe GlobalUid do
     end
 
     after do
-      reset_connections!
       CreateWithNoParams.down
       CreateWithoutGlobalUIDs.down
     end
@@ -307,7 +305,7 @@ describe GlobalUid do
         describe "and all servers report a value other than what's configured" do
           it "raises an exception when configuration incorrect during initialization" do
             GlobalUid::Base.global_uid_options[:increment_by] = 42
-            reset_connections!
+            GlobalUid::Base.disconnect!
             assert_raises(GlobalUid::NoServersAvailableException) { test_unique_ids(10) }
             assert_includes(@notifications, GlobalUid::InvalidIncrementException)
           end
@@ -384,7 +382,7 @@ describe GlobalUid do
           ActiveRecord::Base.__minitest_stub__mysql2_connection(config)
         end
         ActiveRecord::Base.stub :mysql2_connection, modified_connection do
-          reset_connections!
+          GlobalUid::Base.disconnect!
           yield
         end
       end
@@ -482,7 +480,7 @@ describe GlobalUid do
     end
 
     after do
-      reset_connections!
+      GlobalUid::Base.disconnect!
       CreateWithNoParams.down
       CreateWithoutGlobalUIDs.down
     end
@@ -523,7 +521,7 @@ describe GlobalUid do
     end
 
     it "work" do
-      reset_connections!
+      GlobalUid::Base.disconnect!
       2.times.map do
         Thread.new do
           100.times { WithGlobalUID.create! }
@@ -567,7 +565,7 @@ describe GlobalUid do
       end
     end
     ActiveRecord::Base.stub :mysql2_connection, modified_connection do
-      reset_connections!
+      GlobalUid::Base.disconnect!
       yield
     end
   end

--- a/test/lib/global_uid_test.rb
+++ b/test/lib/global_uid_test.rb
@@ -64,21 +64,21 @@ describe GlobalUid do
         end
 
         it "create the global_uids table" do
-          GlobalUid::Base.with_connections do |cx|
-            assert table_exists?(cx, 'with_global_uids_ids'), 'Table should exist'
+          GlobalUid::Base.with_connections do |connection|
+            assert table_exists?(connection, 'with_global_uids_ids'), 'Table should exist'
           end
         end
 
         it "create global_uids tables with matching ids" do
-          GlobalUid::Base.with_connections do |cx|
-            foo = cx.select_all("select id from with_global_uids_ids")
+          GlobalUid::Base.with_connections do |connection|
+            foo = connection.select_all("select id from with_global_uids_ids")
             assert_equal(foo.first['id'].to_i, 1)
           end
         end
 
         it "create tables with the given storage_engine" do
-          GlobalUid::Base.with_connections do |cx|
-            foo = cx.select_all("show create table with_global_uids_ids")
+          GlobalUid::Base.with_connections do |connection|
+            foo = connection.select_all("show create table with_global_uids_ids")
             assert_match(/ENGINE=InnoDB/, foo.first.values.join)
           end
         end
@@ -100,13 +100,13 @@ describe GlobalUid do
       describe "dropping a table" do
         it "not drop the global-uid tables" do
           CreateWithNoParams.up
-          GlobalUid::Base.with_connections do |cx|
-            assert table_exists?(cx, 'with_global_uids_ids'), 'Table should exist'
+          GlobalUid::Base.with_connections do |connection|
+            assert table_exists?(connection, 'with_global_uids_ids'), 'Table should exist'
           end
 
           CreateWithNoParams.down
-          GlobalUid::Base.with_connections do |cx|
-            assert table_exists?(cx, 'with_global_uids_ids'), 'Table should be dropped'
+          GlobalUid::Base.with_connections do |connection|
+            assert table_exists?(connection, 'with_global_uids_ids'), 'Table should be dropped'
           end
         end
       end
@@ -118,8 +118,8 @@ describe GlobalUid do
         end
 
         it "not create the global_uids table" do
-          GlobalUid::Base.with_connections do |cx|
-            assert !table_exists?(cx, 'with_global_uids_ids'), 'Table should not have been created'
+          GlobalUid::Base.with_connections do |connection|
+            assert !table_exists?(connection, 'with_global_uids_ids'), 'Table should not have been created'
           end
         end
 
@@ -133,13 +133,13 @@ describe GlobalUid do
       describe "dropping a table" do
         it "drop the global-uid tables" do
           CreateWithExplicitUidTrue.up
-          GlobalUid::Base.with_connections do |cx|
-            assert table_exists?(cx, 'with_global_uids_ids'), 'Table should exist'
+          GlobalUid::Base.with_connections do |connection|
+            assert table_exists?(connection, 'with_global_uids_ids'), 'Table should exist'
           end
 
           CreateWithExplicitUidTrue.down
-          GlobalUid::Base.with_connections do |cx|
-            assert !table_exists?(cx, 'with_global_uids_ids'), 'Table should be dropped'
+          GlobalUid::Base.with_connections do |connection|
+            assert !table_exists?(connection, 'with_global_uids_ids'), 'Table should be dropped'
           end
         end
       end
@@ -152,8 +152,8 @@ describe GlobalUid do
       end
 
       it "not create the global_uids table" do
-        GlobalUid::Base.with_connections do |cx|
-          assert !table_exists?(cx, 'without_global_uids_ids'), 'Table should not not have been created'
+        GlobalUid::Base.with_connections do |connection|
+          assert !table_exists?(connection, 'without_global_uids_ids'), 'Table should not not have been created'
         end
       end
 
@@ -285,8 +285,8 @@ describe GlobalUid do
 
     describe "normally" do
       it "create tables with the default MyISAM storage engine" do
-        GlobalUid::Base.with_connections do |cx|
-          foo = cx.select_all("show create table with_global_uids_ids")
+        GlobalUid::Base.with_connections do |connection|
+          foo = connection.select_all("show create table with_global_uids_ids")
           assert_match(/ENGINE=MyISAM/, foo.first.values.join)
         end
       end
@@ -442,8 +442,8 @@ describe GlobalUid do
       before do
         # would prefer to do the below, but need Mocha 0.9.10 to do so
         # ActiveRecord::ConnectionAdapters::MysqlAdapter.any_instance.stubs(:execute).raises(ActiveRecord::StatementInvalid)
-        GlobalUid::Base.with_connections do |cx|
-          cx.stubs(:insert).raises(ActiveRecord::StatementInvalid)
+        GlobalUid::Base.with_connections do |connection|
+          connection.stubs(:insert).raises(ActiveRecord::StatementInvalid)
         end
       end
 

--- a/test/performance/creation_test.rb
+++ b/test/performance/creation_test.rb
@@ -5,11 +5,11 @@ describe GlobalUid do
   before do
     Phenix.rise!(with_schema: false)
     ActiveRecord::Base.establish_connection(:test)
-    reset_connections!
     restore_defaults!
   end
 
   after do
+    GlobalUid::Base.disconnect!
     Phenix.burn!
   end
 
@@ -37,7 +37,6 @@ describe GlobalUid do
     end
 
     after do
-      reset_connections!
       CreateWithNoParams.down
       CreateWithoutGlobalUIDs.down
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,10 +33,6 @@ def test_unique_ids(amount = 10)
   end
 end
 
-def reset_connections!
-  GlobalUid::Base.servers = nil
-end
-
 def restore_defaults!
   GlobalUid::Base.global_uid_options = {
     :id_servers => [


### PR DESCRIPTION
Talking it over with @bquorning, there was a lot of changes being made in #70 and it made reviewing difficult. This work is split out from #70 and broken down further.

This patch is a large rework of the internals, adding a Server class which is responsible for all connection handling, moving it out of the GlobalUid::Base, and moving it to private accessors where necessary.

Prior to this, clients could do things they probably shouldn't and as such this patch **includes many breaking changes**, making it harder to reach into the internals.

Due to the amount of change I've tried to keep my commits small to make reviewing easier, commits are either moving code or modifying it, never both at the same time.