### PR TITLE
Add GlobalUid::Configuration class

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - `with_connections` has been replaced by `with_servers` which contains the connection metadata (increment_by, timeout, allocations, etc) (https://github.com/zendesk/global_uid/pull/71)
 - The `per_process_affinity` configuration has been replaced with `connection_shuffling`. The behaviour remains the same, but the default boolean value has flipped – e.g. if you had previously configured `per_process_affinity = false`, you should now set `connection_shuffling = true` to get the same behavior. `connection_shuffling` defaults to false.
+- [Breaking change] Move configuration to a class
 
 ### Removed
 - Removed the `dry_run` option (https://github.com/zendesk/global_uid/pull/64)

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - `with_connections` has been replaced by `with_servers` which contains the connection metadata (increment_by, timeout, allocations, etc) (https://github.com/zendesk/global_uid/pull/71)
+- The `per_process_affinity` configuration has been replaced with `connection_shuffling`. The behaviour remains the same, but the default boolean value has flipped – e.g. if you had previously configured `per_process_affinity = false`, you should now set `connection_shuffling = true` to get the same behavior. `connection_shuffling` defaults to false.
 
 ### Removed
 - Removed the `dry_run` option (https://github.com/zendesk/global_uid/pull/64)

--- a/README.md
+++ b/README.md
@@ -39,25 +39,13 @@ id_server_2:
 Then setup these servers, and other defaults in your environment.rb:
 
 ```rb
-GlobalUid::Base.global_uid_options = {
-  id_servers: [ 'id_server_1', 'id_server_2' ],
-  increment_by: 5
+GlobalUid.configure do |config|
+  config.id_servers = [ 'id_server_1', 'id_server_2' ]
+  config.increment_by = 5
 }
 ```
 
-The `increment_by` value configured here does not dictate the value on your alloc server and must remain in sync with the value of [`auto_increment_increment`](https://dev.mysql.com/doc/refman/5.7/en/replication-options-master.html#sysvar_auto_increment_increment)
-
-Here's a complete list of the options you can use:
-
-| Name                             | Default                                    | Description                                                                                                  |
-| -------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `:disabled`                      | `false`                                    | Disable GlobalUid entirely                                                                                   |
-| `:connection_timeout`            | 3 seconds                                  | Timeout for connecting to a global UID server                                                                |
-| `:query_timeout`                 | 10 seconds                                 | Timeout for retrieving a global UID from a server before we move on to the next server                       |
-| `:connection_retry`              | 10 minutes                                 | After failing to connect or query a UID server, how long before we retry                                     |
-| `:notifier`                      | A proc calling `ActiveRecord::Base.logger` | This proc is called with two parameters upon UID server failure -- an exception and a message                |
-| `:increment_by`                  | 5                                          | Used for validation, compared with the value on the alloc servers to prevent allocation of duplicate IDs     |
-| `:suppress_increment_exceptions` | `false`                                    | Suppress configuration validation, allowing updates to `auto_increment_increment` while alloc servers in use |
+For a full list of configuration options, and their defaults, see `GlobalUid::Configuration`
 
 ### Migration
 

--- a/lib/global_uid.rb
+++ b/lib/global_uid.rb
@@ -2,6 +2,7 @@
 require "global_uid/base"
 require "global_uid/allocator"
 require "global_uid/server"
+require "global_uid/configuration"
 require "global_uid/active_record_extension"
 require "global_uid/has_and_belongs_to_many_builder_extension"
 require "global_uid/migration_extension"
@@ -12,6 +13,19 @@ module GlobalUid
   class ConnectionTimeoutException < StandardError ; end
   class TimeoutException < StandardError ; end
   class InvalidIncrementException < StandardError ; end
+
+  def self.configuration
+    @configuration ||= GlobalUid::Configuration.new
+  end
+
+  def self.configure
+    yield configuration if block_given?
+  end
+
+  # @private
+  def self.reset_configuration
+    @configuration = nil
+  end
 end
 
 ActiveRecord::Base.send(:include, GlobalUid::ActiveRecordExtension)

--- a/lib/global_uid/active_record_extension.rb
+++ b/lib/global_uid/active_record_extension.rb
@@ -8,7 +8,7 @@ module GlobalUid
     end
 
     def global_uid_before_create
-      return if GlobalUid::Base.global_uid_options[:disabled]
+      return if GlobalUid.configuration.disabled?
       return if self.class.global_uid_disabled
 
       self.id = self.class.generate_uid

--- a/lib/global_uid/allocator.rb
+++ b/lib/global_uid/allocator.rb
@@ -59,7 +59,7 @@ module GlobalUid
     end
 
     def alert(exception)
-      if GlobalUid::Base.global_uid_options[:suppress_increment_exceptions]
+      if GlobalUid.configuration.suppress_increment_exceptions?
         GlobalUid::Base.notify(exception, exception.message)
       else
         raise exception

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -13,7 +13,7 @@ module GlobalUid
       :query_timeout        => 10,
       :increment_by         => 5, # This will define the maximum number of servers that you can have
       :disabled             => false,
-      :per_process_affinity => true,
+      :connection_shuffling => false,
       :suppress_increment_exceptions => false
     }
 
@@ -57,7 +57,7 @@ module GlobalUid
       self.servers ||= init_server_info
       servers = self.servers.each(&:connect)
 
-      if !self.global_uid_options[:per_process_affinity]
+      if self.global_uid_options[:connection_shuffling]
         servers.shuffle! # subsequent requests are made against different servers
       end
 

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -16,25 +16,14 @@ module GlobalUid
     end
 
     def self.init_server_info
-      id_servers = GlobalUid.configuration.id_servers
-      increment_by = GlobalUid.configuration.increment_by
-      connection_retry = GlobalUid.configuration.connection_retry
-      connection_timeout = GlobalUid.configuration.connection_timeout
-      query_timeout = GlobalUid.configuration.query_timeout
-
-      raise "You haven't configured any id servers" if id_servers.nil? or id_servers.empty?
-      raise "More servers configured than increment_by: #{id_servers.size} > #{increment_by} -- this will create duplicate IDs." if id_servers.size > increment_by
-
-      servers = id_servers.map do |name|
+      GlobalUid.configuration.id_servers.map do |name|
         GlobalUid::Server.new(name,
-          increment_by: increment_by,
-          connection_retry: connection_retry,
-          connection_timeout: connection_timeout,
-          query_timeout: query_timeout
+          increment_by: GlobalUid.configuration.increment_by,
+          connection_retry: GlobalUid.configuration.connection_retry,
+          connection_timeout: GlobalUid.configuration.connection_timeout,
+          query_timeout: GlobalUid.configuration.query_timeout
         )
-      end
-
-      servers.shuffle # each process uses a random server
+      end.shuffle # so each process uses a random server
     end
 
     def self.disconnect!

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -6,17 +6,6 @@ require "timeout"
 
 module GlobalUid
   class Base
-    GLOBAL_UID_DEFAULTS = {
-      :connection_timeout   => 3,
-      :connection_retry     => 10.minutes,
-      :notifier             => Proc.new { |exception, message| ActiveRecord::Base.logger.error("GlobalUID error: #{exception.class} #{message}") },
-      :query_timeout        => 10,
-      :increment_by         => 5, # This will define the maximum number of servers that you can have
-      :disabled             => false,
-      :connection_shuffling => false,
-      :suppress_increment_exceptions => false
-    }
-
     def self.servers
       # Thread local storage is inheritted on `fork`, include the pid
       Thread.current["global_uid_servers_#{$$}"]
@@ -27,11 +16,11 @@ module GlobalUid
     end
 
     def self.init_server_info
-      id_servers = self.global_uid_servers
-      increment_by = self.global_uid_options[:increment_by]
-      connection_retry = self.global_uid_options[:connection_retry]
-      connection_timeout = self.global_uid_options[:connection_timeout]
-      query_timeout = self.global_uid_options[:query_timeout]
+      id_servers = GlobalUid.configuration.id_servers
+      increment_by = GlobalUid.configuration.increment_by
+      connection_retry = GlobalUid.configuration.connection_retry
+      connection_timeout = GlobalUid.configuration.connection_timeout
+      query_timeout = GlobalUid.configuration.query_timeout
 
       raise "You haven't configured any id servers" if id_servers.nil? or id_servers.empty?
       raise "More servers configured than increment_by: #{id_servers.size} > #{increment_by} -- this will create duplicate IDs." if id_servers.size > increment_by
@@ -57,7 +46,7 @@ module GlobalUid
       self.servers ||= init_server_info
       servers = self.servers.each(&:connect)
 
-      if self.global_uid_options[:connection_shuffling]
+      if GlobalUid.configuration.connection_shuffling?
         servers.shuffle! # subsequent requests are made against different servers
       end
 
@@ -88,21 +77,9 @@ module GlobalUid
     end
 
     def self.notify(exception, message)
-      if self.global_uid_options[:notifier]
-        self.global_uid_options[:notifier].call(exception, message)
+      if GlobalUid.configuration.notifier
+        GlobalUid.configuration.notifier.call(exception, message)
       end
-    end
-
-    def self.global_uid_options=(options)
-      @global_uid_options = GLOBAL_UID_DEFAULTS.merge(options.symbolize_keys)
-    end
-
-    def self.global_uid_options
-      @global_uid_options
-    end
-
-    def self.global_uid_servers
-      self.global_uid_options[:id_servers]
     end
 
     def self.id_table_from_name(name)

--- a/lib/global_uid/configuration.rb
+++ b/lib/global_uid/configuration.rb
@@ -1,0 +1,57 @@
+module GlobalUid
+  class Configuration
+
+    attr_accessor :connection_timeout
+    attr_accessor :connection_retry
+    attr_accessor :notifier
+    attr_accessor :query_timeout
+    attr_accessor :increment_by
+    attr_accessor :disabled
+    attr_accessor :connection_shuffling
+    attr_accessor :suppress_increment_exceptions
+    attr_accessor :storage_engine
+    attr_accessor :id_servers
+
+    alias_method :disabled?, :disabled
+    alias_method :connection_shuffling?, :connection_shuffling
+    alias_method :suppress_increment_exceptions?, :suppress_increment_exceptions
+
+    # Set defaults
+    def initialize
+      # Timeout (in seconds) for connecting to a global UID server
+      @connection_timeout = 3
+
+      # Duration (in seconds) to wait before attempting another connection to UID server
+      @connection_retry = 600 # 10 minutes
+
+      # This proc is called with two parameters upon UID server failure -- an exception and a message
+      @notifier = Proc.new { |exception, message| ActiveRecord::Base.logger.error("GlobalUID error: #{exception.class} #{message}") }
+
+      # Timeout (in seconds) for retrieving a global UID from a server before moving to the next server
+      @query_timeout = 10
+
+      # Used for validation, compared with the value on the alloc servers to prevent allocation of duplicate IDs
+      #   NB: The value configured here does not dictate the value on your alloc server and must remain in
+      #       sync with the value of auto_increment_increment in the database.
+      @increment_by = 5
+
+      # Disable GlobalUid entirely
+      @disabled = false
+
+      # The same allocation server is used each time `with_servers` is called
+      @connection_shuffling = false
+
+      # Suppress configuration validation, allowing updates to auto_increment_increment while alloc servers in use.
+      # The InvalidIncrementException will be swallowed and logged when suppressed
+      @suppress_increment_exceptions = false
+
+      # The name of the alloc DB servers, defined in your database.yml
+      # e.g. ["id_server_1", "id_server_2"]
+      @id_servers = []
+
+      # The storage engine used during GloblaUid table creation
+      # Supported and tested: InnoDB, MyISAM
+      @storage_engine = "MyISAM"
+    end
+  end
+end

--- a/lib/global_uid/configuration.rb
+++ b/lib/global_uid/configuration.rb
@@ -10,7 +10,6 @@ module GlobalUid
     attr_accessor :connection_shuffling
     attr_accessor :suppress_increment_exceptions
     attr_accessor :storage_engine
-    attr_accessor :id_servers
 
     alias_method :disabled?, :disabled
     alias_method :connection_shuffling?, :connection_shuffling
@@ -52,6 +51,16 @@ module GlobalUid
       # The storage engine used during GloblaUid table creation
       # Supported and tested: InnoDB, MyISAM
       @storage_engine = "MyISAM"
+    end
+
+    def id_servers=(value)
+      raise "More servers configured than increment_by: #{value.size} > #{increment_by} -- this will create duplicate IDs." if value.size > increment_by
+      @id_servers = value
+    end
+
+    def id_servers
+      raise "You haven't configured any id servers" if @id_servers.empty?
+      @id_servers
     end
   end
 end

--- a/lib/global_uid/migration_extension.rb
+++ b/lib/global_uid/migration_extension.rb
@@ -3,7 +3,7 @@ module GlobalUid
   module MigrationExtension
 
     def create_table(name, options = {}, &blk)
-      uid_enabled = !(GlobalUid::Base.global_uid_options[:disabled] || options[:use_global_uid] == false)
+      uid_enabled = !(GlobalUid.configuration.disabled? || options[:use_global_uid] == false)
 
       # rules for stripping out auto_increment -- enabled and not a "PK-less" table
       remove_auto_increment = uid_enabled && !(options[:id] == false)
@@ -22,7 +22,7 @@ module GlobalUid
             name: id_table_name,
             uid_type: options[:uid_type] || "bigint(21) UNSIGNED",
             start_id: options[:start_id] || 1,
-            storage_engine: GlobalUid::Base.global_uid_options[:storage_engine] || "MyISAM"
+            storage_engine: GlobalUid.configuration.storage_engine
           )
         end
       end
@@ -30,7 +30,7 @@ module GlobalUid
     end
 
     def drop_table(name, options = {})
-      if !GlobalUid::Base.global_uid_options[:disabled] && options[:use_global_uid] == true
+      if !GlobalUid.configuration.disabled? && options[:use_global_uid] == true
         id_table_name = options[:global_uid_table] || GlobalUid::Base.id_table_from_name(name)
         GlobalUid::Base.with_servers do |server|
           server.drop_uid_table!(name: id_table_name)

--- a/test/lib/global_uid_test.rb
+++ b/test/lib/global_uid_test.rb
@@ -463,7 +463,7 @@ describe GlobalUid do
 
     describe "without shuffling connections" do
       before do
-        GlobalUid::Base.global_uid_options[:per_process_affinity] = true
+        GlobalUid::Base.global_uid_options[:connection_shuffling] = false
       end
 
       it "increment sequentially" do
@@ -488,14 +488,14 @@ describe GlobalUid do
       end
 
       after do
-        GlobalUid::Base.global_uid_options[:per_process_affinity] = false
+        GlobalUid::Base.global_uid_options[:connection_shuffling] = true
       end
     end
 
 
     describe "with connection shuffling" do
       before do
-        GlobalUid::Base.global_uid_options[:per_process_affinity] = false
+        GlobalUid::Base.global_uid_options[:connection_shuffling] = true
       end
 
       it "increment sequentially" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,5 +43,5 @@ def restore_defaults!
 
   # Randomize connections for test processes to ensure they're not
   # sticky during tests
-  GlobalUid::Base.global_uid_options[:per_process_affinity] = false
+  GlobalUid::Base.global_uid_options[:connection_shuffling] = true
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,14 +34,12 @@ def test_unique_ids(amount = 10)
 end
 
 def restore_defaults!
-  GlobalUid::Base.global_uid_options = {
-    :id_servers => [
-      "test_id_server_1",
-      "test_id_server_2"
-    ]
-  }
+  GlobalUid.reset_configuration
+  GlobalUid.configure do |config|
+    config.id_servers = ["test_id_server_1", "test_id_server_2"]
 
-  # Randomize connections for test processes to ensure they're not
-  # sticky during tests
-  GlobalUid::Base.global_uid_options[:connection_shuffling] = true
+    # Randomize connections for test processes to ensure they're not
+    # sticky during tests
+    config.connection_shuffling = true
+  end
 end


### PR DESCRIPTION
**Breaking change**, _Split out from #70_

The gem is now configured like many others, with options like `storage_engine` now being documented.

Clients upgrading will need to update their configuration as the previous implementation is no longer supported.

All supported configuration options live in `GlobalUid::Configuration`, with their respective defaults. New clients of the gem need only set `id_servers` and `increment_by` unless they have a more bespoke setup.

To configure the gem, add the following in a Rails initializer

```
GlobalUid.configure do |config|
  config.id_servers = [ 'id_server_1', 'id_server_2' ]
  config.increment_by = 5
}
```