### PR TITLE
Release v4.0.0.beta1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,21 +6,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [4.0.0] - 2020-04-27
 ### Added
 - [Breaking change] ID Validation, ensure the ID coming back has been incremented using the configured `auto_increment_increment`. (https://github.com/zendesk/global_uid/pull/63)
 - `notify` is called before raising `NoServersAvailableException` (https://github.com/zendesk/global_uid/pull/71)
 
 ### Changed
-- `with_connections` has been replaced by `with_servers` which contains the connection metadata (increment_by, timeout, allocations, etc) (https://github.com/zendesk/global_uid/pull/71)
-- The `per_process_affinity` configuration has been replaced with `connection_shuffling`. The behaviour remains the same, but the default boolean value has flipped – e.g. if you had previously configured `per_process_affinity = false`, you should now set `connection_shuffling = true` to get the same behavior. `connection_shuffling` defaults to false.
-- [Breaking change] Move configuration to a class
-- [Breaking change] The configured `notifier` proc is now called now only with an exception, rather than an exception and a message.
+- [Breaking change] `with_connections` has been replaced by `with_servers` which contains the connection metadata (increment_by, timeout, allocations, etc) (https://github.com/zendesk/global_uid/pull/71)
+- [Breaking change] The `per_process_affinity` configuration has been replaced with `connection_shuffling`. The behaviour remains the same, but the default boolean value has flipped – e.g. if you had previously configured `per_process_affinity = false`, you should now set `connection_shuffling = true` to get the same behavior. `connection_shuffling` defaults to false. (https://github.com/zendesk/global_uid/pull/72)
+- [Breaking change] Move configuration to a class (https://github.com/zendesk/global_uid/pull/72)
+- [Breaking change] The configured `notifier` proc is now called now only with an exception, rather than an exception and a message. (https://github.com/zendesk/global_uid/pull/73)
 
 ### Removed
-- Removed the `dry_run` option (https://github.com/zendesk/global_uid/pull/64)
-- Removed `GlobalUid::ServerVariables` module (https://github.com/zendesk/global_uid/pull/66)
+- [Breaking change] Removed the `dry_run` option (https://github.com/zendesk/global_uid/pull/64)
+- [Breaking change] Removed `GlobalUid::ServerVariables` module (https://github.com/zendesk/global_uid/pull/66)
 - Removed `options` parameter from `generate_uid` & `generate_many_uids` (https://github.com/zendesk/global_uid/pull/68)
-- The following methods on `GlobalUid::Base` are no longer accessible as they're for internal use only (https://github.com/zendesk/global_uid/pull/71)
+- [Breaking change] The following methods on `GlobalUid::Base` are no longer accessible as they're for internal use only (https://github.com/zendesk/global_uid/pull/71)
   - `GlobalUid::Base.setup_connections!`
   - `GlobalUid::Base.get_uid_for_class`
   - `GlobalUid::Base.get_many_uids_for_class`

--- a/docs/upgrading-to-4-0.md
+++ b/docs/upgrading-to-4-0.md
@@ -1,0 +1,17 @@
+This release includes non-backwards compatible changes.
+
+## Upgrading from 3.x to 4.x
+
+* The `auto_increment_increment` on the allocation servers is compared with the configured `increment_by` and an exception is raised if they don't match. Use the `suppress_increment_exceptions` configuration option if this is expected.
+* Make sure you weren't using any of the private APIs that were removed in https://github.com/zendesk/global_uid/pull/71.
+* The `GlobalUid::ServerVariables` module has been removed (https://github.com/zendesk/global_uid/pull/66), update your database.yml to configure the increment and offset values for the development/test DB.
+* Update your configuration to use the new interface (https://github.com/zendesk/global_uid/pull/72).
+```ruby
+GlobalUid.configure do |config|
+  config.id_servers = [ 'id_server_1', 'id_server_2' ]
+  config.increment_by = 5
+  config.notifier = Proc.new { |exception| do_something_with(exception) }
+}
+```
+* The `dry_run` configuration option is no longer supported and has been removed.
+* The `per_process_affinity` configuration option was replaced with `connection_shuffling` (https://github.com/zendesk/global_uid/pull/72). If you had previously configured `per_process_affinity = false`, you should now set `connection_shuffling = true` to get the same behaviour. `connection_shuffling` defaults to false.

--- a/global_uid.gemspec
+++ b/global_uid.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'global_uid', '3.7.1' do |s|
+Gem::Specification.new 'global_uid', '4.0.0.beta1' do |s|
   s.summary     = "GUID"
   s.description = "GUIDs for sharded models"
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Ben Osheroff"]


### PR DESCRIPTION
This release includes non-backwards compatible changes. 

## Upgrading from 3.x to 4.x

* The `auto_increment_increment` on the allocation servers is compared with the configured `increment_by` and an exception is raised if they don't match. Use the `suppress_increment_exceptions` configuration option if this is expected.
* Make sure you weren't using any of the private APIs that were removed in https://github.com/zendesk/global_uid/pull/71.
* The `GlobalUid::ServerVariables` module has been removed (https://github.com/zendesk/global_uid/pull/66), update your database.yml to configure the increment and offset values for the development/test DB.
* Update your configuration to use the new interface (https://github.com/zendesk/global_uid/pull/72).
```ruby
GlobalUid.configure do |config|
  config.id_servers = [ 'id_server_1', 'id_server_2' ]
  config.increment_by = 5
  config.notifier = Proc.new { |exception| do_something_with(exception) }
}
```
* The `dry_run` configuration option is no longer supported and has been removed.
* The `per_process_affinity` configuration option was replaced with `connection_shuffling` (https://github.com/zendesk/global_uid/pull/72). If you had previously configured `per_process_affinity = false`, you should now set `connection_shuffling = true` to get the same behaviour. `connection_shuffling` defaults to false.