### PR TITLE
Add GlobalUid::TestSupport for recreating ID tables in test environments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (from 3.7.0 onwards).
 
 ## [Unreleased]
+### Added
+- A `GlobalUid::TestSupport` module has been introduced to assist with creating, droppping and recreating ID tables.
 
 ## [4.0.0.beta1] - 2020-04-27
 ### Added

--- a/lib/global_uid/migration_extension.rb
+++ b/lib/global_uid/migration_extension.rb
@@ -20,9 +20,8 @@ module GlobalUid
         GlobalUid::Base.with_servers do |server|
           server.create_uid_table!(
             name: id_table_name,
-            uid_type: options[:uid_type] || "bigint(21) UNSIGNED",
-            start_id: options[:start_id] || 1,
-            storage_engine: GlobalUid.configuration.storage_engine
+            uid_type: options[:uid_type],
+            start_id: options[:start_id]
           )
         end
       end

--- a/lib/global_uid/server.rb
+++ b/lib/global_uid/server.rb
@@ -45,13 +45,16 @@ module GlobalUid
       @allocator = nil
     end
 
-    def create_uid_table!(name:, uid_type:, start_id:, storage_engine:)
+    def create_uid_table!(name:, uid_type: nil, start_id: nil)
+      uid_type ||= "bigint(21) UNSIGNED"
+      start_id ||= 1
+
       connection.execute("CREATE TABLE IF NOT EXISTS `#{name}` (
       `id` #{uid_type} NOT NULL AUTO_INCREMENT,
       `stub` char(1) NOT NULL DEFAULT '',
       PRIMARY KEY (`id`),
       UNIQUE KEY `stub` (`stub`)
-      ) ENGINE=#{storage_engine}")
+      ) ENGINE=#{GlobalUid.configuration.storage_engine}")
 
       # prime the pump on each server
       connection.execute("INSERT IGNORE INTO `#{name}` VALUES(#{start_id}, 'a')")

--- a/lib/global_uid/test_support.rb
+++ b/lib/global_uid/test_support.rb
@@ -1,0 +1,44 @@
+module GlobalUid
+  module TestSupport
+    # Tables should be created through the MigrationExtension but
+    # if you want to manually create and drop the '_id' tables,
+    # you can do so via this module
+    class << self
+      def create_uid_tables(tables: [], uid_type: nil, start_id: nil)
+        return if GlobalUid.configuration.disabled?
+
+        GlobalUid::Base.with_servers do |server|
+          tables.each do |table|
+            server.create_uid_table!(
+              name: GlobalUid::Base.id_table_from_name(table),
+              uid_type: uid_type,
+              start_id: start_id
+            )
+          end
+        end
+      end
+
+      def drop_uid_tables(tables: [])
+        return if GlobalUid.configuration.disabled?
+
+        GlobalUid::Base.with_servers do |server|
+          tables.each do |table|
+            server.drop_uid_table!(
+              name: GlobalUid::Base.id_table_from_name(table)
+            )
+          end
+        end
+      end
+
+      def recreate_uid_tables(tables: [], uid_type: nil, start_id: nil)
+        return if GlobalUid.configuration.disabled?
+
+        drop_uid_tables(tables: tables)
+        create_uid_tables(tables: tables, uid_type: nil, start_id: start_id)
+
+        # Reset the servers, clearing any allocations from memory
+        GlobalUid::Base.disconnect!
+      end
+    end
+  end
+end

--- a/test/lib/test_support_test.rb
+++ b/test/lib/test_support_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+require 'global_uid/test_support'
+
+describe GlobalUid::TestSupport do
+  before do
+    Phenix.rise!(with_schema: false)
+    ActiveRecord::Base.establish_connection(:test)
+    restore_defaults!
+  end
+
+  after do
+    GlobalUid::Base.disconnect!
+    Phenix.burn!
+  end
+
+  def table_exists?(connection, table)
+    if ActiveRecord::VERSION::MAJOR >= 5
+      connection.data_source_exists?(table)
+    else
+      connection.table_exists?(table)
+    end
+  end
+
+  class Foo < ActiveRecord::Base
+  end
+
+  class Bar < ActiveRecord::Base
+  end
+
+  it 'recreates the tables' do
+    # Check the tables aren't there
+    GlobalUid::Base.with_servers do |server|
+      refute table_exists?(server.connection, Foo.global_uid_table), 'Table should not exist'
+      refute table_exists?(server.connection, Bar.global_uid_table), 'Table should not exist'
+    end
+
+    # Create the tables
+    GlobalUid::TestSupport.create_uid_tables(tables: [Foo.table_name, Bar.table_name])
+    GlobalUid::Base.with_servers do |server|
+      assert table_exists?(server.connection, Foo.global_uid_table), 'Table should exist'
+      assert table_exists?(server.connection, Bar.global_uid_table), 'Table should exist'
+    end
+
+    # Add some data, ensuring it's cleared when recreate is called
+    GlobalUid::Base.with_servers do |server|
+      3.times { server.allocate(Foo) }
+    end
+    assert_operator GlobalUid::Base.servers.first.allocate(Foo), :>=, 15
+
+    # Verify that the tables are dropped and recreated
+    GlobalUid::TestSupport.recreate_uid_tables(tables: [Foo.table_name, Bar.table_name])
+    GlobalUid::Base.with_servers do |server|
+      server.allocate(Foo)
+    end
+    assert_operator GlobalUid::Base.servers.first.allocate(Foo), :<=, 15
+  end
+end


### PR DESCRIPTION
Clients using earlier versions of the gem would execute code like the following block when restoring the database from a schema dump.

```ruby
unless GlobalUid::Base.global_uid_options[:disabled]
  non_global_uid_tables = ["ar_internal_metadata"]
  table_list = ActiveRecord::Base.connection.data_sources

  (table_list - non_global_uid_tables).each do |table|
    GlobalUid::Base.drop_uid_tables(table + "_ids")
    GlobalUid::Base.create_uid_tables(table + "_ids", options)
  end
end
```

If the schema dump doesn't include global_uid table information, this patch allows them to create the ID tables after the fact. For example, the code above should be updated to:

```ruby
require 'global_uid/test_support'

table_list = ActiveRecord::Base.connection.data_sources - ["ar_internal_metadata"]
GlobalUid::TestSupport.recreate_uid_tables(tables: table_list)
```

It should only be used in development and test environments. The `MigrationExtension` is responsible for creating these tables when you create models with global_uid.