### PR TITLE
v4.0.0.beta2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,11 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (from 3.7.0 onwards).
 
 ## [Unreleased]
-### Added
-- A `GlobalUid::TestSupport` module has been introduced to assist with creating, droppping and recreating ID tables.
 
+## [4.0.0.beta2] - 2020-04-30
 ### Added
-- `GlobalUid.enabled?`, `GlobalUid.disabled?`, `GlobalUid.disable!` & `GlobalUid.enable!` helper methods added.
+- A `GlobalUid::TestSupport` module has been introduced to assist with creating, droppping and recreating ID tables. (https://github.com/zendesk/global_uid/pull/76)
+- `GlobalUid.enabled?`, `GlobalUid.disabled?`, `GlobalUid.disable!` & `GlobalUid.enable!` helper methods added. (https://github.com/zendesk/global_uid/pull/77)
 
 ## [4.0.0.beta1] - 2020-04-27
 ### Added

--- a/global_uid.gemspec
+++ b/global_uid.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'global_uid', '4.0.0.beta1' do |s|
+Gem::Specification.new 'global_uid', '4.0.0.beta2' do |s|
   s.summary     = "GUID"
   s.description = "GUIDs for sharded models"
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Ben Osheroff"]


### PR DESCRIPTION
Cutting a release with the following changes:

### Added

- A `GlobalUid::TestSupport` module has been introduced to assist with creating, droppping and recreating ID tables. (https://github.com/zendesk/global_uid/pull/76)
- `GlobalUid.enabled?`, `GlobalUid.disabled?`, `GlobalUid.disable!` & `GlobalUid.enable!` helper methods added. (https://github.com/zendesk/global_uid/pull/77)