### PR TITLE
Add test for table start_id option

### DIFF
--- a/test/support/migrations.rb
+++ b/test/support/migrations.rb
@@ -47,3 +47,15 @@ class CreateWithoutGlobalUIDs < MigrationClass
     drop_table :without_global_uids, :use_global_uid => false
   end
 end
+
+class CreateWithGlobalUIDAndCustomStart < MigrationClass
+  group :change if self.respond_to?(:group)
+
+  def self.up
+    create_table(:with_global_uid_and_custom_start, start_id: 10_000) { }
+  end
+
+  def self.down
+    drop_table :with_global_uid_and_custom_start
+  end
+end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -6,6 +6,10 @@ class WithoutGlobalUID < ActiveRecord::Base
   disable_global_uid
 end
 
+class WithGlobalUIDAndCustomStart < ActiveRecord::Base
+  self.table_name = 'with_global_uid_and_custom_start'
+end
+
 class Parent < ActiveRecord::Base
   def self.reset
     @global_uid_disabled = nil


### PR DESCRIPTION
Clients can pass in a `start_id` when creating the UID tables but we had
no spec coverage for it. Ensure the functionality works as expected.