### PR TITLE
Fix validation error when working with multiple models

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (from 3.7.0 onwards).
 
 ## [Unreleased]
+### Fixed
+ - ID allocation validation now takes the table name into consideration. Prior to this change the server would allocate multiple IDs (e.g. 2 & 2) from different tables using global UIDs and incorrectly raise a InvalidIncrementException.
 
 ## [4.0.0.beta2] - 2020-04-30
 ### Added

--- a/lib/global_uid/active_record_extension.rb
+++ b/lib/global_uid/active_record_extension.rb
@@ -48,7 +48,7 @@ module GlobalUid
       end
 
       def global_uid_table
-        GlobalUid::Base.id_table_from_name(self.table_name)
+        @_global_uid_table ||= GlobalUid::Base.id_table_from_name(self.table_name)
       end
     end
   end

--- a/lib/global_uid/base.rb
+++ b/lib/global_uid/base.rb
@@ -68,5 +68,13 @@ module GlobalUid
     def self.id_table_from_name(name)
       "#{name}_ids".to_sym
     end
+
+    def self.alert(exception)
+      if GlobalUid.configuration.suppress_increment_exceptions?
+        GlobalUid.configuration.notifier.call(exception)
+      else
+        raise exception
+      end
+    end
   end
 end

--- a/test/lib/allocator_test.rb
+++ b/test/lib/allocator_test.rb
@@ -4,92 +4,96 @@ require_relative '../test_helper'
 describe GlobalUid::Allocator do
   let(:connection)   { mock('connection') }
   let(:increment_by) { 10 }
-  let(:allocator)    { GlobalUid::Allocator.new(incrementing_by: increment_by, connection: connection) }
-  let(:table)        { mock('table_class').class }
+  let(:allocator)    { GlobalUid::Allocator.new(incrementing_by: increment_by, connection: connection, table_name: 'uid_table_name') }
 
   before do
     restore_defaults!
     connection.stubs(:current_database).returns('database_name')
+    connection.stubs(:select_value).with('SELECT @@auto_increment_increment').returns(increment_by)
   end
 
-  describe 'with a configured increment_by that differs from the connections auto_increment_increment' do
-    it 'raises an exception to prevent erroneous ID allocation' do
-      connection.stubs(:select_value).with('SELECT @@auto_increment_increment').returns(50)
-      exception = assert_raises(GlobalUid::InvalidIncrementException) do
-        GlobalUid::Allocator.new(incrementing_by: 10, connection: connection)
+  describe '#allocate_one' do
+    it 'allocates IDs, maintaining a small rolling selection of IDs for comparison' do
+      [10, 20, 30, 40, 50, 60, 70, 80].each do |id|
+        connection.expects(:insert).returns(id)
+        allocator.allocate_one
       end
 
-      assert_equal("Configured: '10', Found: '50' on 'database_name'", exception.message)
+      assert_equal(5, allocator.max_window_size)
+      assert_equal([40, 50, 60, 70, 80], allocator.recent_allocations)
+    end
+
+    describe 'gap between ID not divisible by increment_by' do
+      it 'raises an error' do
+        connection.expects(:insert).returns(20)
+        allocator.allocate_one
+
+        connection.stubs(:select_value).with('SELECT @@auto_increment_increment').returns(5)
+        connection.expects(:insert).returns(25)
+        exception = assert_raises(GlobalUid::InvalidIncrementException) do
+          allocator.allocate_one
+        end
+
+        assert_equal("Configured: '10', Found: '5' on 'database_name'. Recently allocated IDs: [20, 25] using table 'uid_table_name'", exception.message)
+      end
+    end
+
+    describe 'ID value does not increment upwards' do
+      it 'raises an error' do
+        connection.expects(:insert).returns(20)
+        allocator.allocate_one
+
+        connection.expects(:insert).returns(10)
+        exception = assert_raises(GlobalUid::InvalidIncrementException) do
+          allocator.allocate_one
+        end
+
+        assert_equal("Configured: '10', Found: '10' on 'database_name'. Recently allocated IDs: [20, 10] using table 'uid_table_name'", exception.message)
+      end
     end
   end
 
-  describe 'with a configured increment_by that matches the connections auto_increment_increment' do
-    before do
-      connection.stubs(:select_value).with('SELECT @@auto_increment_increment').returns(increment_by)
+  describe '#allocate_many' do
+    it 'allocates IDs, maintaining a small rolling selection of IDs for comparison' do
+      connection.expects(:insert)
+        .with("REPLACE INTO uid_table_name (stub) VALUES ('a'),('a'),('a'),('a'),('a'),('a'),('a'),('a')")
+        .returns(10)
+      allocator.allocate_many(count: 8)
+
+      assert_equal(5, allocator.max_window_size)
+      assert_equal([40, 50, 60, 70, 80], allocator.recent_allocations)
     end
 
-    describe '#allocate_one' do
-      it 'allocates IDs, maintaining a small rolling selection of IDs for comparison' do
-        [10, 20, 30, 40, 50, 60, 70, 80].each do |id|
-          connection.expects(:insert).returns(id)
-          allocator.allocate_one(table)
-        end
-
-        assert_equal(5, allocator.max_window_size)
-        assert_equal([40, 50, 60, 70, 80], allocator.recent_allocations)
-      end
-
-      describe 'gap between ID not divisible by increment_by' do
-        it 'raises an error' do
-          connection.expects(:insert).returns(20)
-          allocator.allocate_one(table)
-
-          connection.stubs(:select_value).with('SELECT @@auto_increment_increment').returns(5)
-          connection.expects(:insert).returns(25)
-          exception = assert_raises(GlobalUid::InvalidIncrementException) do
-            allocator.allocate_one(table)
-          end
-
-          assert_equal("Configured: '10', Found: '5' on 'database_name'. Recently allocated IDs: [20, 25]", exception.message)
-        end
-      end
-
-      describe 'ID value does not increment upwards' do
-        it 'raises an error' do
-          connection.expects(:insert).returns(20)
-          allocator.allocate_one(table)
-
-          connection.expects(:insert).returns(20 - increment_by)
-          exception = assert_raises(GlobalUid::InvalidIncrementException) do
-            allocator.allocate_one(table)
-          end
-
-          assert_equal("Configured: '10', Found: '10' on 'database_name'. Recently allocated IDs: [20, 10]", exception.message)
-        end
-      end
-    end
-
-    describe '#allocate_many' do
-      it 'allocates IDs, maintaining a small rolling selection of IDs for comparison' do
+    describe 'gap between ID not divisible by increment_by' do
+      it 'raises an error' do
         connection.expects(:insert)
-          .with("REPLACE INTO Mocha::Mock (stub) VALUES ('a'),('a'),('a'),('a'),('a'),('a'),('a'),('a')")
+          .with("REPLACE INTO uid_table_name (stub) VALUES ('a'),('a'),('a'),('a'),('a'),('a'),('a'),('a')")
           .returns(10)
-        allocator.allocate_many(table, count: 8)
+        allocator.allocate_many(count: 8)
 
-        assert_equal(5, allocator.max_window_size)
-        assert_equal([40, 50, 60, 70, 80], allocator.recent_allocations)
-      end
-
-      describe 'with a configured increment_by that differs from the active connection auto_increment_increment' do
-        it 'raises an error' do
-          connection.stubs(:select_value).with('SELECT @@auto_increment_increment').returns(5)
-          connection.expects(:insert).never
-          exception = assert_raises(GlobalUid::InvalidIncrementException) do
-            allocator.allocate_many(table, count: 8)
-          end
-
-          assert_equal("Configured: '10', Found: '5' on 'database_name'", exception.message)
+        connection.stubs(:select_value).with('SELECT @@auto_increment_increment').returns(5)
+        connection.expects(:insert).returns(25)
+        exception = assert_raises(GlobalUid::InvalidIncrementException) do
+          allocator.allocate_many(count: 8)
         end
+
+        assert_equal("Configured: '10', Found: '5' on 'database_name'. Recently allocated IDs: [50, 60, 70, 80, 25] using table 'uid_table_name'", exception.message)
+      end
+    end
+
+    describe 'ID value does not increment upwards' do
+      it 'raises an error' do
+        connection.expects(:insert)
+          .with("REPLACE INTO uid_table_name (stub) VALUES ('a'),('a'),('a'),('a'),('a'),('a'),('a'),('a')")
+          .returns(10)
+        allocator.allocate_many(count: 8)
+
+        connection.expects(:insert).returns(10)
+        exception = assert_raises(GlobalUid::InvalidIncrementException) do
+          allocator.allocate_many(count: 8)
+        end
+
+        assert_equal("Configured: '10', Found: '10' on 'database_name'. Recently allocated IDs: [50, 60, 70, 80, 10] using table 'uid_table_name'", exception.message)
       end
     end
   end

--- a/test/lib/global_uid_test.rb
+++ b/test/lib/global_uid_test.rb
@@ -497,8 +497,8 @@ describe GlobalUid do
         end
 
         # The same allocation server is used each time `with_servers` is called
-        refute_empty(GlobalUid::Base.servers[0].send(:allocator).recent_allocations)
-        assert_empty(GlobalUid::Base.servers[1].send(:allocator).recent_allocations)
+        refute_empty(GlobalUid::Base.servers[0].send(:allocator, WithGlobalUID).recent_allocations)
+        assert_empty(GlobalUid::Base.servers[1].send(:allocator, WithGlobalUID).recent_allocations)
       end
 
       it 'still selects a connection at random on initialization' do
@@ -529,8 +529,8 @@ describe GlobalUid do
         end
 
         # A different allocation server is used each time `with_servers` is called
-        refute_empty(GlobalUid::Base.servers[0].send(:allocator).recent_allocations)
-        refute_empty(GlobalUid::Base.servers[1].send(:allocator).recent_allocations)
+        refute_empty(GlobalUid::Base.servers[0].send(:allocator, WithGlobalUID).recent_allocations)
+        refute_empty(GlobalUid::Base.servers[1].send(:allocator, WithGlobalUID).recent_allocations)
       end
 
       it 'still selects a connection at random on initialization' do

--- a/test/lib/global_uid_test.rb
+++ b/test/lib/global_uid_test.rb
@@ -263,14 +263,14 @@ describe GlobalUid do
 
       it "allows the increment to be updated" do
         # Prefill alloc servers with a few records, initializing a connection to both alloc servers
-        test_unique_ids(25)
+        test_unique_ids(model: WithGlobalUID, amount: 25)
         assert_empty(@notifications)
 
         # Update the active `test_id_server_1` connection, setting a `auto_increment_increment`
         # value that differs to what's configured and expected
         # The change should be noted and record creation should continue on both servers
         with_modified_connections(increment: 10, servers: ["test_id_server_1"]) do
-          test_unique_ids(25)
+          test_unique_ids(model: WithGlobalUID, amount: 25)
           assert_includes(@notifications, GlobalUid::InvalidIncrementException)
           assert_equal(2, active_connections.length)
         end
@@ -280,7 +280,7 @@ describe GlobalUid do
         # The change should be noted and record creation should continue on both servers
         @notifications = []
         with_modified_connections(increment: 10, servers: ["test_id_server_1", "test_id_server_2"]) do
-          test_unique_ids(25)
+          test_unique_ids(model: WithGlobalUID, amount: 25)
           assert_includes(@notifications, GlobalUid::InvalidIncrementException)
           assert_equal(2, active_connections.length)
         end
@@ -296,6 +296,7 @@ describe GlobalUid do
   describe "With GlobalUID" do
     before do
       CreateWithNoParams.up
+      CreateAnotherWithGlobalUids.up
       CreateWithoutGlobalUIDs.up
     end
 
@@ -308,7 +309,7 @@ describe GlobalUid do
       end
 
       it "get a unique id" do
-        test_unique_ids
+        test_unique_ids(models: [WithGlobalUID, AnotherWithGlobalUID], amount: 10)
       end
 
       describe 'when the auto_increment_increment changes' do
@@ -325,7 +326,7 @@ describe GlobalUid do
           it "raises an exception when configuration incorrect during initialization" do
             GlobalUid.configuration.increment_by = 42
             GlobalUid::Base.disconnect!
-            assert_raises(GlobalUid::NoServersAvailableException) { test_unique_ids(10) }
+            assert_raises(GlobalUid::NoServersAvailableException) { test_unique_ids(models: [WithGlobalUID, AnotherWithGlobalUID], amount: 10) }
             assert_includes(@notifications, GlobalUid::InvalidIncrementException)
           end
 
@@ -334,7 +335,7 @@ describe GlobalUid do
               server.connection.execute("SET SESSION auto_increment_increment = 42")
             end
 
-            assert_raises(GlobalUid::NoServersAvailableException) { test_unique_ids(10) }
+            assert_raises(GlobalUid::NoServersAvailableException) { test_unique_ids(models: [WithGlobalUID, AnotherWithGlobalUID], amount: 10) }
             assert_includes(@notifications, GlobalUid::InvalidIncrementException)
           end
 
@@ -355,7 +356,7 @@ describe GlobalUid do
             end
             # Due to multiple processes and threads sharing the same alloc server, identifiers may be provisioned
             # before the current thread receives its next one. We rely on the gap being divisible by the configured increment
-            test_unique_ids(10)
+            test_unique_ids(models: [WithGlobalUID, AnotherWithGlobalUID], amount: 10)
             assert_empty(@notifications)
           end
         end
@@ -365,7 +366,7 @@ describe GlobalUid do
             with_modified_connections(increment: 42, servers: ["test_id_server_1"]) do
 
               # Trigger the exception, one call may not hit the server, there's still a 1/(2^32) chance of failure.
-              test_unique_ids(32)
+              test_unique_ids(models: [WithGlobalUID, AnotherWithGlobalUID], amount: 32)
               assert_includes(@notifications, GlobalUid::InvalidIncrementException)
             end
           end
@@ -375,7 +376,7 @@ describe GlobalUid do
             con.execute("SET SESSION auto_increment_increment = 42")
 
             # Trigger the exception, one call may not hit the server, there's still a 1/(2^32) chance of failure.
-            test_unique_ids(32)
+            test_unique_ids(models: [WithGlobalUID, AnotherWithGlobalUID], amount: 32)
             assert_includes(@notifications, GlobalUid::InvalidIncrementException)
           end
 
@@ -384,7 +385,10 @@ describe GlobalUid do
             con.execute("SET SESSION auto_increment_increment = 42")
 
             # Trigger the exception, one call may not hit the server, there's still a 1/(2^32) chance of failure.
-            32.times { WithGlobalUID.generate_many_uids(10) }
+            32.times do
+              WithGlobalUID.generate_many_uids(10)
+              AnotherWithGlobalUID.generate_many_uids(10)
+            end
             assert_includes(@notifications, GlobalUid::InvalidIncrementException)
           end
         end
@@ -408,7 +412,7 @@ describe GlobalUid do
 
       it "limp along with one functioning server" do
         with_timed_out_connection(server: "test_id_server_1", end_time: Time.now + 10.minutes) do
-          test_unique_ids(10)
+          test_unique_ids(model: WithGlobalUID, amount: 10)
           assert_equal 1, active_connections.length
           assert_equal 'global_uid_test_id_server_2', active_connections[0].current_database
         end
@@ -416,14 +420,14 @@ describe GlobalUid do
 
       it "eventually retry the connection and get it back in place" do
         with_timed_out_connection(server: "test_id_server_1", end_time: Time.now + 10.minutes) do
-          test_unique_ids(10)
+          test_unique_ids(model: WithGlobalUID, amount: 10)
           assert_equal 1, active_connections.length
           assert_equal 'global_uid_test_id_server_2', active_connections[0].current_database
 
           after_timeout_end_time = Time.now + 11.minutes
           Time.stubs(:now).returns(after_timeout_end_time)
 
-          test_unique_ids(10)
+          test_unique_ids(model: WithGlobalUID, amount: 10)
           assert_equal 2, active_connections.length
         end
       end
@@ -442,7 +446,7 @@ describe GlobalUid do
       end
 
       it "get ids from the remaining server" do
-        test_unique_ids
+        test_unique_ids(model: WithGlobalUID, amount: 10)
       end
 
       it "eventually retry the connection" do
@@ -451,7 +455,7 @@ describe GlobalUid do
         awhile = Time.now + 10.minutes
         Time.stubs(:now).returns(awhile)
 
-        test_unique_ids
+        test_unique_ids(model: WithGlobalUID, amount: 10)
         assert_equal 2, active_connections.length
       end
     end
@@ -543,6 +547,7 @@ describe GlobalUid do
     after do
       GlobalUid::Base.disconnect!
       CreateWithNoParams.down
+      CreateAnotherWithGlobalUids.down
       CreateWithoutGlobalUIDs.down
     end
   end
@@ -600,16 +605,22 @@ describe GlobalUid do
   describe "generate_many_uids" do
     before do
       CreateWithNoParams.up
+      CreateAnotherWithGlobalUids.up
     end
 
     it "generates many unique ids" do
       uids = WithGlobalUID.generate_many_uids(100)
       assert_equal uids.sort, uids
       assert_equal uids.uniq, uids
+
+      uids = AnotherWithGlobalUID.generate_many_uids(100)
+      assert_equal uids.sort, uids
+      assert_equal uids.uniq, uids
     end
 
     after do
       CreateWithNoParams.down
+      CreateAnotherWithGlobalUids.down
     end
   end
 

--- a/test/support/migrations.rb
+++ b/test/support/migrations.rb
@@ -20,6 +20,20 @@ class CreateWithNoParams < MigrationClass
   end
 end
 
+class CreateAnotherWithGlobalUids < MigrationClass
+  group :change if self.respond_to?(:group)
+
+  def self.up
+    create_table :another_with_global_uids do |t|
+      t.string  :description
+    end
+  end
+
+  def self.down
+    drop_table :another_with_global_uids
+  end
+end
+
 class CreateWithExplicitUidTrue < MigrationClass
   group :change if self.respond_to?(:group)
 

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -10,6 +10,9 @@ class WithGlobalUIDAndCustomStart < ActiveRecord::Base
   self.table_name = 'with_global_uid_and_custom_start'
 end
 
+class AnotherWithGlobalUID  < ActiveRecord::Base
+end
+
 class Parent < ActiveRecord::Base
   def self.reset
     @global_uid_disabled = nil

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,13 +23,15 @@ ActiveRecord::Base.logger = Logger.new(File.join(File.dirname(__FILE__), "test.l
 ActiveSupport.test_order = :sorted if ActiveSupport.respond_to?(:test_order=)
 ActiveRecord::Migration.verbose = false
 
-def test_unique_ids(amount = 10)
-  amount.times.each_with_object({}) do |_, seen|
-    record = WithGlobalUID.create!
-    refute_nil record.id
-    assert_nil record.description
-    refute seen.has_key?(record.id)
-    seen[record.id] = true
+def test_unique_ids(model: nil, models: [model], amount: 0)
+  models.each do |model|
+    amount.times.each_with_object({}) do |_, seen|
+      record = model.create!
+      refute_nil record.id
+      assert_nil record.description
+      refute seen.has_key?(record.id)
+      seen[record.id] = true
+    end
   end
 end
 


### PR DESCRIPTION
Each model using global_uids has an ID table created for it on the
allocation server. If we're keeping track of recently allocated IDs, we
need to scope it by table name as the sequence between tables will be
different.

To resolve this, the Server now contains a hash of Allocators, keyed by 
table name. The Server will validate the `increment_by` value on the DB
during connection initialization, and whenever an allocation is made
we'll create or retrieve an allocator for that table, using validated
connection reference.

The connection validation was moved to reduce overhead, performing
it per table, per process would impact performance and as a result of
this, some of the specs have been moved around.