### PR TITLE
Fix generate_many_ids(1), should return an array.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (from 3.7.0 onwards).
 
 ## [Unreleased]
+### Fixed
+ - `generate_many_ids(1)` would return the ID; It's now returned within an Array, fixing a breaking API change when clients upgraded from v3.x to v4.x.
 
 ## [4.0.0] - 2020-08-26
 

--- a/lib/global_uid/active_record_extension.rb
+++ b/lib/global_uid/active_record_extension.rb
@@ -35,7 +35,7 @@ module GlobalUid
 
       def generate_many_uids(count)
         GlobalUid::Base.with_servers do |server|
-          return server.allocate(self, count: count)
+          return Array(server.allocate(self, count: count))
         end
       end
 

--- a/test/lib/global_uid_test.rb
+++ b/test/lib/global_uid_test.rb
@@ -618,6 +618,13 @@ describe GlobalUid do
       assert_equal uids.uniq, uids
     end
 
+    it "can be used to generate just one unique id" do
+      uids = WithGlobalUID.generate_many_uids(1)
+
+      assert_instance_of Array, uids
+      assert_equal uids.size, 1
+    end
+
     after do
       CreateWithNoParams.down
       CreateAnotherWithGlobalUids.down


### PR DESCRIPTION
The implementation changed during the move to v4 and generating one ID would return the ID itself instead of an array.

With this patch, `generate_many_uids` will once again return an array, no matter the count.