### PR TITLE
v4.0.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (from 3.7.0 onwards).
 
 ## [Unreleased]
+
+## [4.0.1] - 2020-09-10
 ### Fixed
- - `generate_many_ids(1)` would return the ID; It's now returned within an Array, fixing a breaking API change when clients upgraded from v3.x to v4.x.
+ - `generate_many_ids(1)` would return the ID; It's now returned within an Array, fixing a breaking API change when clients upgraded from v3.x to v4.x. (https://github.com/zendesk/global_uid/pull/86)
 
 ## [4.0.0] - 2020-08-26
 

--- a/global_uid.gemspec
+++ b/global_uid.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'global_uid', '4.0.0' do |s|
+Gem::Specification.new 'global_uid', '4.0.1' do |s|
   s.summary     = "GUID"
   s.description = "GUIDs for sharded models"
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Ben Osheroff"]


### PR DESCRIPTION
### Fixed
 - `generate_many_ids(1)` would return the ID; It's now returned within an Array, fixing a breaking API change when clients upgraded from v3.x to v4.x. (https://github.com/zendesk/global_uid/pull/86)