### PR TITLE
Allow using with Rails 6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,13 @@ jobs:
     environment:
       BUNDLE_GEMFILE: gemfiles/rails6.0.gemfile
     <<: *run_tests
+  test-2.5-with-6.1:
+    docker:
+      - image: circleci/ruby:2.5
+      - image: circleci/mysql:5.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails6.1.gemfile
+    <<: *run_tests
 
   # Ruby 2.6
   test-2.6-with-4.2:
@@ -93,6 +100,13 @@ jobs:
     environment:
       BUNDLE_GEMFILE: gemfiles/rails6.0.gemfile
     <<: *run_tests
+  test-2.6-with-6.1:
+    docker:
+      - image: circleci/ruby:2.6
+      - image: circleci/mysql:5.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails6.1.gemfile
+    <<: *run_tests
 
   # Ruby 2.7
   test-2.7-with-5.1:
@@ -116,6 +130,13 @@ jobs:
     environment:
       BUNDLE_GEMFILE: gemfiles/rails6.0.gemfile
     <<: *run_tests
+  test-2.7-with-6.1:
+    docker:
+      - image: circleci/ruby:2.7
+      - image: circleci/mysql:5.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails6.1.gemfile
+    <<: *run_tests
 
 workflows:
   version: 2
@@ -130,12 +151,15 @@ workflows:
       - test-2.5-with-5.1
       - test-2.5-with-5.2
       - test-2.5-with-6.0
+      - test-2.5-with-6.1
 
       - test-2.6-with-4.2
       - test-2.6-with-5.1
       - test-2.6-with-5.2
       - test-2.6-with-6.0
+      - test-2.6-with-6.1
 
       - test-2.7-with-5.1
       - test-2.7-with-5.2
       - test-2.7-with-6.0
+      - test-2.7-with-6.1

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 6.1.0'

--- a/global_uid.gemspec
+++ b/global_uid.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new 'global_uid', '4.0.1' do |s|
 
   s.required_ruby_version = "~> 2.4"
 
-  s.add_dependency('activerecord', '>= 4.2.0', '< 6.1')
+  s.add_dependency('activerecord', '>= 4.2.0', '< 6.2')
   s.add_dependency('activesupport')
   s.add_dependency('mysql2')
 

--- a/lib/global_uid/server.rb
+++ b/lib/global_uid/server.rb
@@ -106,14 +106,25 @@ module GlobalUid
       nil
     end
 
-    def mysql2_config(name)
-      raise "No id server '#{name}' configured in database.yml" unless ActiveRecord::Base.configurations.to_h.has_key?(name)
-      config = ActiveRecord::Base.configurations.to_h[name]
+    if ActiveRecord.version < Gem::Version.new('6.1.0')
+      def mysql2_config(name)
+        raise "No id server '#{name}' configured in database.yml" unless ActiveRecord::Base.configurations.to_h.has_key?(name)
+        config = ActiveRecord::Base.configurations.to_h[name]
 
-      c = config.symbolize_keys
-      raise "No global_uid support for adapter #{c[:adapter]}" if c[:adapter] != 'mysql2'
+        c = config.symbolize_keys
+        raise "No global_uid support for adapter #{c[:adapter]}" if c[:adapter] != 'mysql2'
 
-      config
+        config
+      end
+    else
+      def mysql2_config(name)
+        config = ActiveRecord::Base.configurations.configs_for(env_name: name, name: 'primary')
+
+        raise "No id server '#{name}' configured in database.yml" if config.nil?
+        raise "No global_uid support for adapter #{config.adapter}" if config.adapter != 'mysql2'
+
+        config.configuration_hash
+      end
     end
 
     def validate_connection_increment

--- a/lib/global_uid/server.rb
+++ b/lib/global_uid/server.rb
@@ -93,11 +93,7 @@ module GlobalUid
     end
 
     def mysql2_connection(name)
-      raise "No id server '#{name}' configured in database.yml" unless ActiveRecord::Base.configurations.to_h.has_key?(name)
-      config = ActiveRecord::Base.configurations.to_h[name]
-      c = config.symbolize_keys
-
-      raise "No global_uid support for adapter #{c[:adapter]}" if c[:adapter] != 'mysql2'
+      config = mysql2_config(name)
 
       Timeout.timeout(connection_timeout, ConnectionTimeoutException) do
         ActiveRecord::Base.mysql2_connection(config)
@@ -108,6 +104,16 @@ module GlobalUid
     rescue Exception => e
       GlobalUid.configuration.notifier.call(StandardError.new("establishing a connection to #{name}: #{e.message}"))
       nil
+    end
+
+    def mysql2_config(name)
+      raise "No id server '#{name}' configured in database.yml" unless ActiveRecord::Base.configurations.to_h.has_key?(name)
+      config = ActiveRecord::Base.configurations.to_h[name]
+
+      c = config.symbolize_keys
+      raise "No global_uid support for adapter #{c[:adapter]}" if c[:adapter] != 'mysql2'
+
+      config
     end
 
     def validate_connection_increment

--- a/test/lib/global_uid_test.rb
+++ b/test/lib/global_uid_test.rb
@@ -398,7 +398,7 @@ describe GlobalUid do
     describe "With a timing out server" do
       def with_timed_out_connection(server:, end_time:)
         modified_connection = lambda do |config|
-          if config["database"].include?(server)
+          if config.symbolize_keys[:database].include?(server)
             raise GlobalUid::ConnectionTimeoutException if end_time > Time.now
           end
 
@@ -645,7 +645,7 @@ describe GlobalUid do
   def with_modified_connections(increment:, servers:)
     modified_connection = lambda do |config|
       ActiveRecord::Base.__minitest_stub__mysql2_connection(config).tap do |connection|
-        if servers.any? { |name| config["database"].include?(name) }
+        if servers.any? { |name| config.symbolize_keys[:database].include?(name) }
           connection.execute("SET SESSION auto_increment_increment = #{increment}")
         end
       end


### PR DESCRIPTION
~There is a deprecation warning that we should probably fix:~

    DEPRECATION WARNING: to_h is deprecated and will be removed from Rails 6.2 (You can use
    `ActiveRecord::Base.configurations.configs_for(env_name: 'env', name: 'primary').configuration_hash` to get
    the configuration hashes.) (called from mysql2_connection at [...]/global_uid/lib/global_uid/server.rb:96)

Fixed!

In Rails 6.1, the database configurations, and each database configuration, are now real objects. And the hash representation of a database configuration has symbolized keys in Rails 6.1. With these few changes in mind, we actually need only a few changes for making this gem compatible with 6.1.