### PR TITLE
Test with Ruby 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,22 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/rails7.0.gemfile
     <<: *run_tests
 
+  # Ruby 3.1
+  test-3.1-with-6.1:
+    docker:
+      - image: cimg/ruby:3.1.2
+      - image: circleci/mysql:5.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails6.1.gemfile
+    <<: *run_tests
+  test-3.1-with-7.0:
+    docker:
+      - image: cimg/ruby:3.1.2
+      - image: circleci/mysql:5.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails7.0.gemfile
+    <<: *run_tests
+
 workflows:
   version: 2
   build:
@@ -198,3 +214,6 @@ workflows:
       - test-3.0-with-6.0
       - test-3.0-with-6.1
       - test-3.0-with-7.0
+
+      - test-3.1-with-6.1
+      - test-3.1-with-7.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (from 3.7.0 onwards).
 
 ## [Unreleased]
+- Support for Ruby 3.1. (https://github.com/zendesk/global_uid/pull/96)
 - Support for Rails 7.0. (https://github.com/zendesk/global_uid/pull/95)
 
 ## [4.2.0] - 2022-04-06

--- a/global_uid.gemspec
+++ b/global_uid.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new 'global_uid', '4.2.0' do |s|
 
   s.add_development_dependency('rake')
   s.add_development_dependency('bundler')
-  s.add_development_dependency('minitest')
+  s.add_development_dependency('minitest', '~> 5.15.0')
   s.add_development_dependency('minitest-rg')
   s.add_development_dependency('minitest-line')
   s.add_development_dependency('mocha')


### PR DESCRIPTION
Had to switch to the `cimg/ruby:3.1.2` image since the other image was not found.

Had to keep `minitest` at `v5.15.0` in order to bundle with the Ruby versions we're testing. There are other ways of handling this but this seems simplest for a gem that's supposed to be archived.