### PR TITLE
Release v4.3.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (from 3.7.0 onwards).
 
 ## [Unreleased]
+
+## [4.3.0] - 2022-11-14
 - Support for Ruby 3.1. (https://github.com/zendesk/global_uid/pull/96)
 - Support for Rails 7.0. (https://github.com/zendesk/global_uid/pull/95)
 

--- a/global_uid.gemspec
+++ b/global_uid.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'global_uid', '4.2.0' do |s|
+Gem::Specification.new 'global_uid', '4.3.0' do |s|
   s.summary     = "GUID"
   s.description = "GUIDs for sharded models"
   s.authors     = ["Benjamin Quorning", "Gabe Martin-Dempesy", "Pierre Schambacher", "Ben Osheroff"]


### PR DESCRIPTION
Releasing:

- Support for Ruby 3.1. (https://github.com/zendesk/global_uid/pull/96)
- Support for Rails 7.0. (https://github.com/zendesk/global_uid/pull/95)